### PR TITLE
feat(debug): add launch.json configs & debug scripts for frontend/backend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,44 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Launch via NPM",
-            "request": "launch",
-            "runtimeArgs": [
-                "run",
-                "dev"
-            ],
-            "runtimeExecutable": "npm",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "type": "node"
-        }
-       
-    ],
-    "debug.javascript.terminalOptions": {
-        "skipFiles": [
-          "<node_internals>/**"
-        ]
-      },
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // 後端除錯
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Backend (Node)",
+      "program": "${workspaceFolder}/server.js",
+      "runtimeExecutable": "nodemon",
+      "runtimeArgs": ["--inspect"],
+      "skipFiles": ["<node_internals>/**"],
+      "env": {
+        "NODE_ENV": "development"
+      }
+    },
+    {
+      // CRA 前端啟動
+      "type": "node",
+      "request": "launch",
+      "name": "Start Frontend (CRA)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "cwd": "${workspaceFolder}/client",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      // CLI 模式（npm run dev）
+      "type": "node",
+      "request": "launch",
+      "name": "Full Stack via npm run dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "cwd": "${workspaceFolder}",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Full Stack (Backend + CRA)",
+      "configurations": ["Debug Backend (Node)", "Start Frontend (CRA)"]
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "client": "npm start --prefix client",
     "clientinstall": "npm install --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
-     "render-postbuild": "npm install --prefix client && npm run build --prefix client && mkdir -p build && cp -r client/build/* build/"
+    "server:debug": "nodemon --inspect server.js",
+    "dev:debug": "concurrently \"npm run server:debug\" \"npm run client\"",
+    "render-postbuild": "npm install --prefix client && npm run build --prefix client && mkdir -p build && cp -r client/build/* build/"
   },
   "author": "",
   "license": "ISC",
@@ -39,6 +41,6 @@
     "url": "^0.11.3"
   },
   "engines": {
-     "node": ">=18.12.0"
+    "node": ">=18.12.0"
   }
 }


### PR DESCRIPTION
## 變更內容

- 新增 `.vscode/launch.json` 配置，包含：
  - `Debug Backend (Node)`
  - `Start Frontend (CRA)`
  - `Full Stack Debug Mode`（整合 dev:debug 腳本）

- 調整 `package.json` scripts：
  - 新增 `server:debug`：啟用後端除錯模式
  - 新增 `dev:debug`：同時啟動前後端除錯環境

## scripts 範例

```json
"scripts": {
  "server": "nodemon server.js",
  "client": "npm start --prefix client",
  "dev": "concurrently \"npm run server\" \"npm run client\"",
  "server:debug": "nodemon --inspect server.js",
  "dev:debug": "concurrently \"npm run server:debug\" \"npm run client\""
}
```

##  補充說明

- 不影響原本 `npm run dev` 啟動方式
- 可透過 VSCode debug 面板或 Chrome DevTools (`chrome://inspect`) 連接後端斷點
- 支援 React 前端與 Node.js 後端獨立或整合式除錯

## 測試方式

- `npm run dev`：原有 CLI 無異常
- `npm run dev:debug`：成功開啟 9229 port 並啟動前後端
- VSCode 可使用 `launch.json` 中的 `Full Stack Debug Mode` 啟動除錯流程
