### PR TITLE
feat(auth): include user role in JWT payload and set token expiration

### DIFF
--- a/client/src/pages/LoginPage.js
+++ b/client/src/pages/LoginPage.js
@@ -54,7 +54,13 @@ const LoginPage = ({ currentUser, setCurrentUser, showAlert }) => {
           navigate("/profile");
         }, 500);
       } catch (e) {
-        setMessage(e.response.data);
+        const fallbackMsg = "登入失敗，請稍後再試";
+        if (e.response && e.response.data) {
+          const serverMsg = e.response.data.message || e.response.data;
+          setMessage(typeof serverMsg === "string" ? serverMsg : fallbackMsg);
+        } else {
+          setMessage(fallbackMsg);
+        }
       } finally {
         setIsLoading(false);
       }

--- a/config/passport.js
+++ b/config/passport.js
@@ -12,8 +12,12 @@ module.exports = (passport) => {
     new JwtStrategy(opts, async function (jwt_payload, done) {
       console.log(jwt_payload);
       try {
-        let foundUser = await User.findOne({ _id: jwt_payload._id }).exec();
+        let foundUser = await User.findOne({ _id: jwt_payload._id })
+          .select("-password") // 不回傳密碼欄位
+          .exec();
         if (foundUser) {
+          // 從 payload 補上 role，避免再次查詢
+          foundUser.role = jwt_payload.role;
           return done(null, foundUser); //req,user <= foundUser
         } else {
           return done(null, false);
@@ -24,5 +28,3 @@ module.exports = (passport) => {
     })
   );
 };
-
-// passport被執行後會自動套入passport套件

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,119 +1,81 @@
 const router = require("express").Router();
-const registerValidation = require("../validation").registerValidation;
-const loginValidation = require("../validation").loginValidation;
+const { registerValidation, loginValidation } = require("../validation");
 const User = require("../models").user;
 const jwt = require("jsonwebtoken");
 
-// router.use((req, res, next) => {
-//   console.log("正在接收一個跟auth有關的請求");
-//   next();
-// });
-
-// router.post("/register", async (req, res) => {
-//   // 確認註冊資訊是否符合規範
-//   let { error } = registerValidation(req.body);
-//   if (error) {
-//     return res.status(400).send(error.details[0].message);
-//   }
-
-//   // 確認信箱是否被註冊過
-//   const emailExist = await User.findOne({ email: req.body.email });
-//   if (emailExist) return res.status(400).send("此信箱已註冊過");
-
-//   // 創立新帳號
-//   let { username, email, password, role } = req.body;
-//   let newUser = new User({ username, email, password, role });
-//   try {
-//     let saveUser = await newUser.save();
-//     return res.send({ msg: "成功新增使用者", saveUser });
-//   } catch (e) {
-//     return res.status(500).send(e.message, "新增使用者失敗");
-//   }
-// });
-
-// // 製作webtoken
-// router.post("/login", async (req, res) => {
-//   // 確認數據是否符合規範
-//   let { error } = loginValidation(req.body);
-//   if (error) {
-//     return res.status(400).send(error.details[0].message);
-//   }
-//   // 確認信箱是否被註冊過
-//   const foundUser = await User.findOne({ email: req.body.email });
-//   if (!foundUser) {
-//     return res.status(401).send("無法找到使用者，請確認信箱是否正確");
-//   }
-
-//   foundUser.comparePassword(req.body.password, (err, isMatch) => {
-//     if (err) return res.status(500).send(err);
-//     if (isMatch) {
-//       // 製作json web token
-//       const tokenObject = { _id: foundUser._id, email: foundUser.email };
-//       const token = jwt.sign(tokenObject, process.env.PASSPORT_SECRET);
-//       return res.send({
-//         msg: "登入成功",
-//         token: "JWT " + token,
-//         user: foundUser,
-//       });
-//     } else {
-//       return res.status(401).send("密碼錯誤");
-//     }
-//   });
-// });
+// helper function for error response
+const returnError = (res, status, msg) =>
+  res.status(status).json({ success: false, message: msg });
 
 router.post("/register", async (req, res) => {
   try {
     // 確認註冊資訊是否符合規範
-    let { error } = registerValidation(req.body);
-    if (error) {
-      return res.status(400).send(error.details[0].message);
-    }
+    const { error } = registerValidation(req.body);
+    if (error) return returnError(res, 400, error.details[0].message);
 
     // 確認信箱是否被註冊過
     const emailExist = await User.findOne({ email: req.body.email });
-    if (emailExist) return res.status(400).send("此信箱已註冊過");
+    if (emailExist) return returnError(res, 400, "此信箱已註冊過");
 
     // 創立新帳號
     let { username, email, password, role } = req.body;
     let newUser = new User({ username, email, password, role });
     let savedUser = await newUser.save();
-    return res.send({ msg: "成功新增使用者", savedUser });
+    // return res.send({ msg: "成功新增使用者", savedUser });
+    return res.status(201).json({
+      success: true,
+      message: "成功註冊",
+      data: { _id: savedUser._id, username, email, role },
+    });
   } catch (e) {
-    return res.status(500).send("新增使用者失敗: " + e.message);
+    // return res.status(500).send("新增使用者失敗: " + e.message);
+    return returnError(res, 500, "新增使用者失敗: " + e.message);
   }
 });
 
-// 製作webtoken
+//登入 製作webtoken
 router.post("/login", async (req, res) => {
   try {
     // 確認數據是否符合規範
-    let { error } = loginValidation(req.body);
+    const { error } = loginValidation(req.body);
     if (error) {
-      return res.status(400).send(error.details[0].message);
+      return returnError(res, 400, error.details[0].message);
     }
 
     // 確認信箱是否被註冊過
     const foundUser = await User.findOne({ email: req.body.email });
     if (!foundUser) {
-      return res.status(401).send("無法找到使用者，請確認信箱是否正確");
+      return returnError(res, 401, "無法找到使用者，請確認信箱是否正確");
     }
 
     // 比較密碼
     const isMatch = await foundUser.comparePassword(req.body.password);
-    if (isMatch) {
-      // 製作json web token
-      const tokenObject = { _id: foundUser._id, email: foundUser.email };
-      const token = jwt.sign(tokenObject, process.env.PASSPORT_SECRET);
-      return res.send({
-        msg: "登入成功",
-        token: "JWT " + token,
-        user: foundUser,
-      });
-    } else {
-      return res.status(401).send("密碼錯誤");
-    }
+    if (!isMatch) return returnError(res, 401, "密碼錯誤");
+
+    // 將JWT payload 加上 role
+    const tokenObject = {
+      _id: foundUser._id,
+      email: foundUser.email,
+      role: foundUser.role,
+    };
+
+    const token = jwt.sign(tokenObject, process.env.PASSPORT_SECRET, {
+      expiresIn: "1d",
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: "登入成功",
+      token: "JWT " + token,
+      user: {
+        _id: foundUser._id,
+        username: foundUser.username,
+        email: foundUser.email,
+        role: foundUser.role,
+      },
+    });
   } catch (e) {
-    return res.status(500).send("登入過程中發生錯誤: " + e.message);
+    return returnError(res, 500, "登入過程中發生錯誤: " + e.message);
   }
 });
 


### PR DESCRIPTION
- 登入成功時，將使用者 `role` 一併寫入 JWT payload，便於 client-side 權限控管
- passport 驗證時，保留 JWT 中的 `role`，避免重複查詢 DB 以優化效能
- 新增 JWT 的過期設定：`expiresIn: '1d'`，強化 token 使用安全性