### PR TITLE
feat(nav, enroll): 全域搜尋欄 & 互動式註冊課程按鈕

### DIFF
--- a/client/src/components/layout/Nav.js
+++ b/client/src/components/layout/Nav.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import AuthService from "../../services/auth.service";
 import { formatCountdown } from "../../utils/timeUtils";
 import logo from "../../assets/logo.png";
@@ -9,12 +9,28 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
   const [showBanner, setShowBanner] = useState(true);
   const [countdownTime, setCountdownTime] = useState(10800);
   const navigate = useNavigate();
+  const [keyword, setKeyword] = useState("");
+  const location = useLocation();
+
+  // 若離開 /enroll，就重設 Nav 的輸入框，避免殘留文字
+  useEffect(() => {
+    if (location.pathname !== "/enroll") setKeyword("");
+  }, [location.pathname]);
 
   const handleLogout = () => {
     AuthService.logout();
     showAlert("已登出!", "您將被導向至首頁", "elegant", 500);
     setCurrentUser(null);
     navigate("/");
+  };
+
+  const submitSearchFromNav = (e) => {
+    e.preventDefault();
+    if (!keyword.trim()) return showAlert("請輸入關鍵字");
+
+    // 導向 /enroll 並攜帶 keyword
+    navigate("/enroll", { state: { keyword } });
+    showAlert("搜尋中…", "", "elegant", 1500);
   };
 
   useEffect(() => {
@@ -61,6 +77,24 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
               style={{ maxHeight: "70px" }}
             />
           </Link>
+          <form
+            className="d-flex ms-3"
+            role="search"
+            onSubmit={submitSearchFromNav}
+          >
+            <input
+              className="form-control me-2"
+              type="search"
+              placeholder="搜尋課程"
+              aria-label="Search"
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+            />
+            <button className="btn btn-outline-primary" type="submit">
+              Search
+            </button>
+          </form>
+
           <button
             className="navbar-toggler"
             type="button"

--- a/client/src/pages/EnrollPage.js
+++ b/client/src/pages/EnrollPage.js
@@ -1,206 +1,103 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+// src/pages/EnrollPage.js
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import CourseService from "../services/course.service";
 import CourseCardS from "../components/course/CourseCardScroller";
 import CourseImage from "../components/course/CourseImage";
-import bannerImgS from "../assets/bannerimg2-s.jpg";
-import enrollImg from "../assets/enroll-img-v1.jpg";
-import enrollMobile from "../assets/enroll-mobile-v1.png";
-import enrollDesktop from "../assets/enroll-desktop-v1.png";
 
-const EnrollPage = ({ currentUser, setCurrentUser, showAlert }) => {
+const EnrollPage = ({ currentUser, showAlert }) => {
   const navigate = useNavigate();
-  let [searchInput, setSearchInput] = useState("");
-  let [searchResult, setSearchResult] = useState([]);
-  let [searchError, setSearchError] = useState("");
+  const location = useLocation();
 
-  const handleTakeToLogin = () => {
-    navigate("/login");
-  };
+  const [searchResult, setSearchResult] = useState([]);
+  const [searchError, setSearchError] = useState("");
 
-  const handleChangeInput = (e) => {
-    setSearchInput(e.target.value);
-    setSearchError("");
-  };
-  const handleSubmitSearch = (e) => {
-    e.preventDefault();
-    handleSearch();
-  };
-  const handleSearch = () => {
-    if (!searchInput.trim()) {
-      setSearchError("請輸入搜索關鍵字");
+  /* ───── 進頁即判斷是否帶 keyword ───── */
+  useEffect(() => {
+    const kw = location.state?.keyword?.trim();
+    if (kw) runSearch(kw);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.state]);
+
+  /* ───── 搜尋核心 ───── */
+  const runSearch = (keyword) => {
+    if (!keyword) {
+      setSearchResult([]);
+      setSearchError("請輸入搜尋關鍵字");
       return;
     }
 
-    CourseService.getCourseByName(searchInput)
-      .then((data) => {
-        console.log(data);
-        if (data.data && data.data.length > 0) {
-          setSearchResult(data.data);
+    CourseService.getCourseByName(keyword)
+      .then(({ data }) => {
+        if (data?.length) {
+          setSearchResult(data);
           setSearchError("");
         } else {
           setSearchResult([]);
-          setSearchError(
-            `找不到與 ${searchInput} 相關的課程。請嘗試其他關鍵詞，或瀏覽我們的全部課程。`
-          );
+          setSearchError(`找不到與「${keyword}」相關的課程，請再試一次。`);
         }
       })
-      .catch((err) => {
-        console.log(err);
-        setSearchError("搜索過程中出現錯誤，請稍後再試");
+      .catch(() => {
+        setSearchResult([]);
+        setSearchError("搜尋過程中發生錯誤，請稍後再試。");
       });
   };
 
-  const handleEnroll = (e) => {
-    CourseService.enroll(e.target.id)
+  /* ───── 註冊課程（含登入／身分檢查） ───── */
+  const handleEnrollClick = (courseId) => {
+    // 未登入
+    if (!currentUser) {
+      showAlert("請先登入", "註冊課程前，請先登入學生帳號。", "elegant", 2000);
+      return;
+    }
+
+    // 不是學生
+    if (currentUser.user.role === "instructor") {
+      showAlert("無法註冊", "註冊請轉換至學生身分", "elegant", 3000);
+      return;
+    }
+
+    // OK → 呼叫 API
+    CourseService.enroll(courseId)
       .then(() => {
-        showAlert("課程註冊成功!", "將導向到課程頁面。", "elegant", 500);
+        showAlert("課程註冊成功!", "將導向到課程頁面。", "elegant", 3000);
         navigate("/course");
       })
       .catch((err) => {
-        console.log(err);
+        console.error(err);
+        showAlert("檢查註冊狀態失敗", "請稍後再試", "error", 3000);
       });
   };
 
+  /* ───── JSX ───── */
   return (
     <div>
-      {!currentUser && (
-        <div className="enroll-container">
-          <div className="d-flex align-items-center justify-content-center flex-column-reverse flex-md-row">
-            <div className=" col-md-5 p-4 mt-4">
-              <h2 className="mb-3">
-                讓職涯
-                <br />
-                邁向新高峰
-              </h2>
-              <p className="mb-4">
-                訂閱存取科技、商業等多個領域中最受好評的課程系列，
-                <br />
-                讓工作與生活都更上一層樓。
-              </p>
-              <button
-                className="btn btn-dark rounded-0 w-50"
-                onClick={handleTakeToLogin}
-              >
-                立即開始
-              </button>
-            </div>
-            <div className="col-md-6">
-              <picture>
-                <source
-                  srcSet={enrollMobile}
-                  width="1340"
-                  height="400"
-                  media="(max-width: 768px)"
-                ></source>
-
-                <img
-                  className="img-fluid w-100"
-                  alt="Banner"
-                  src={enrollDesktop}
-                  loading="lazy"
-                />
-              </picture>
-            </div>
-          </div>
+      {searchError && (
+        <div className="alert alert-info text-center mx-auto mt-4 w-50">
+          {searchError}
         </div>
       )}
 
-      {currentUser && currentUser.user.role === "instructor" && (
-        <div className="banner-container">
-          <div className="w-100">
-            <picture>
-              <source
-                srcSet={bannerImgS}
-                width="1340"
-                height="400"
-                media="(max-width: 768px)"
-              ></source>
-
-              <img
-                className="img-fluid w-100"
-                alt="Banner"
-                src={enrollImg}
-                loading="lazy"
-              />
-            </picture>
-          </div>
-
-          <div className="text-container bg-light p-4 ms-4">
-            <h2 className="mb-3">立即開始學習</h2>
-            <p className="mb-4">擁有學生帳號，才能註冊課程 </p>
-            <button
-              className="btn btn-dark rounded-0 w-100 "
-              onClick={handleTakeToLogin}
-            >
-              立即開始
-            </button>
-          </div>
-        </div>
-      )}
-
-      {currentUser && currentUser.user.role === "student" && (
-        <div className="px-5 pt-2 mt-5   d-flex flex-column  justify-content-center align-items-center ">
-          <form
-            onSubmit={handleSubmitSearch}
-            className="search input-group mb-3 w-50 border"
-          >
-            <input
-              onChange={handleChangeInput}
-              type="text"
-              className="form-control"
-              placeholder="搜尋課程"
-              value={searchInput}
-            />
-            <button type="submit" className="btn btn-primary custom-button">
-              Search
-            </button>
-          </form>
-          {searchError && (
-            <div className="alert alert-info mt-3 w-50 text-center">
-              {searchError}
-            </div>
-          )}
-        </div>
-      )}
-
-      {!(currentUser && searchResult && searchResult.length !== 0) && (
+      {searchResult.length === 0 ? (
         <div className="px-5 py-4 mb-5">
           <h4 className="mt-5">為您推薦</h4>
           <CourseCardS
-            croller
+            scroller
             showAlert={showAlert}
             currentUser={currentUser}
           />
         </div>
-      )}
+      ) : (
+        <div className="container">
+          <h5 className="mt-4 mb-3">搜尋到以下課程 :</h5>
 
-      {currentUser && searchResult && searchResult.length !== 0 && (
-        <div className=" container">
-          <h5 className="m-2">搜尋到以下課程 :</h5>
           <div className="row">
             {searchResult.map((course) => (
               <div
                 key={course._id}
                 className="col-12 col-sm-6 col-md-4 col-lg-3 mb-4"
               >
-                <div
-                  className="card h-100 border-0 shadow-sm "
-                  style={{
-                    transition: "all 0.3s ease-in-out",
-                    cursor: "pointer",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.boxShadow =
-                      "0 8px 16px rgba(0,0,0,0.15)";
-                    e.currentTarget.style.transform = "translateY(-4px)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.boxShadow =
-                      "0 2px 4px rgba(0,0,0,0.05)";
-                    e.currentTarget.style.transform = "translateY(0)";
-                  }}
-                >
+                <div className="card h-100 border-0 shadow-sm">
                   <CourseImage course={course} height="180px" width="100%" />
                   <div className="card-body d-flex flex-column">
                     <h5 className="card-title fw-bold mt-3">{course.title}</h5>
@@ -213,10 +110,10 @@ const EnrollPage = ({ currentUser, setCurrentUser, showAlert }) => {
                       <li>講師：{course.instructor.username}</li>
                     </ul>
                   </div>
+
                   <button
-                    id={course._id}
-                    onClick={handleEnroll}
-                    className=" btn btn-sm custom-button btn-primary m-3"
+                    onClick={() => handleEnrollClick(course._id)}
+                    className="btn btn-sm btn-primary m-3"
                   >
                     註冊課程
                   </button>


### PR DESCRIPTION
Nav
- 新增搜尋輸入框，submit 時以 navigate("/enroll", { state:{ keyword } }) 導向 EnrollPage
- 空白關鍵字即阻擋並 showAlert("請輸入關鍵字")

EnrollPage
- 移除原本頁內搜尋表單，改為讀取 route state keyword → 自動 runSearch
- 新增「註冊課程」按鈕，onClick 檢查：
  • 未登入        → showAlert("請先登入")
  • role ≠ student → showAlert("無法註冊")
  • student       → CourseService.enroll() 成功後導向 /course
- 若後端錯誤或無結果，友善提示 searchError

BREAKING CHANGE: 無