### PR TITLE
Harden auth: use validated value + strip student inviteCode + stripUnknown at boundary

### DIFF
--- a/client/src/components/course/CourseDetails.js
+++ b/client/src/components/course/CourseDetails.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import CourseService from "../../services/course.service";
+import AuthService from "../../services/auth.service";
 
 const CourseDetails = ({ course, isNearRightEdge, showAlert, currentUser }) => {
   const navigate = useNavigate();
@@ -21,8 +22,12 @@ const CourseDetails = ({ course, isNearRightEdge, showAlert, currentUser }) => {
       showAlert("請先登入", "註冊課程前，請先登入學生帳號。", "elegant", 1000);
       return;
     }
-    // 身分限制
-    if (currentUser.user?.role === "instructor") {
+
+    // 重構前：直接檢查角色
+    // if (currentUser.user?.role === "instructor")
+
+    // 重構後：使用AuthService
+    if (!AuthService.canEnrollCourse(currentUser)) {
       showAlert("無法註冊", "註冊請轉換至學生身分", "elegant", 2000);
       return;
     }

--- a/client/src/components/layout/Nav.js
+++ b/client/src/components/layout/Nav.js
@@ -126,10 +126,16 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
                 <>
                   <NavItem to="/" text="首頁" />
                   <NavItem to="/course" text="課程頁面" />
-                  {currentUser.user.role === "instructor" && (
+                   {/* 重構前：直接檢查角色
+                   {currentUser.user.role === "instructor" && (<NavItem to="/CreateCourse" text="新增課程" />)}
+                  
+                   重構後：使用AuthService */}
+                  {/* 講師才能新增課程 */}
+                  {AuthService.canCreateCourse(currentUser) && (
                     <NavItem to="/CreateCourse" text="新增課程" />
                   )}
-                  {currentUser.user.role === "student" && (
+                  {/* 學生才能註冊課程 */}
+                  {AuthService.canEnrollCourse(currentUser) && (
                     <NavItem to="/enroll" text="註冊課程" />
                   )}
                   <NavItem to="/profile" text="個人頁面" />

--- a/client/src/pages/RegisterPage.js
+++ b/client/src/pages/RegisterPage.js
@@ -32,12 +32,6 @@ const RegisterPage = ({ showAlert }) => {
     document.getElementById("username-input")?.focus();
   }, []);
 
-  const validateForm = () => {
-    const { isValid, errors } = validateWithSchema(registerSchema, formData);
-    setErrors(errors);
-    return isValid;
-  };
-
   const passwordStrength = (password) => {
     let strength = 0;
     if (password.length >= 8) strength++;
@@ -51,13 +45,18 @@ const RegisterPage = ({ showAlert }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     // 用 schema 驗證
-    if (!validateForm()) return;
+    const { isValid, errors, value } = validateWithSchema(
+      registerSchema,
+      formData
+    );
+    setErrors(errors);
+    if (!isValid) return;
 
     setIsLoading(true);
     setServerError("");
 
     try {
-      await AuthService.register(formData);
+      await AuthService.register(value);
 
       showAlert("註冊成功!", "您將被導向至登入頁面。", "elegant", 1500);
       setTimeout(() => navigate("/login"), 1500);
@@ -100,7 +99,7 @@ const RegisterPage = ({ showAlert }) => {
               }`}
               placeholder=" "
             />
-            <label htmlFor="username" className="custom-label">
+            <label htmlFor="username-input" className="custom-label">
               <span>用戶名稱</span>
             </label>
             {errors.username && (
@@ -182,13 +181,18 @@ const RegisterPage = ({ showAlert }) => {
                 <label className="form-label">講師授權碼</label>
                 <input
                   type="password"
-                  className="form-control"
+                  className={`form-control ${
+                    errors.inviteCode ? "is-invalid" : ""
+                  }`}
                   placeholder="請輸入授權碼"
                   autoComplete="off"
                   name="inviteCode"
                   value={formData.inviteCode}
                   onChange={handleChange}
                 />
+                {errors.inviteCode && (
+                  <div className="invalid-feedback">{errors.inviteCode}</div>
+                )}
                 <div className="form-text mb-3 text-danger">
                   僅授權人員可成為講師
                 </div>

--- a/client/src/services/auth.service.js
+++ b/client/src/services/auth.service.js
@@ -1,6 +1,8 @@
 import axios from "axios";
+import courseService from "./course.service";
 
 const API_URL = `${process.env.REACT_APP_API_BASE_URL}/api/user`;
+
 class AuthService {
   login(email, password) {
     return axios.post(`${API_URL}/login`, {
@@ -17,6 +19,47 @@ class AuthService {
 
   getCurrentUser() {
     return JSON.parse(localStorage.getItem("user"));
+  }
+
+  // 🆕 權限檢查方法
+  canCreateCourse(user) {
+    return user?.user?.role === "instructor";
+  }
+
+  canEnrollCourse(user) {
+    return user?.user?.role === "student";
+  }
+
+  canEditCourse(user, course) {
+    return (
+      user?.user?.role === "instructor" &&
+      course?.instructor?._id === user?.user?._id
+    );
+  }
+
+  canDropCourse(user) {
+    return user?.user?.role === "student";
+  }
+
+  isInstructor(user) {
+    return user?.user?.role === "instructor";
+  }
+
+  isStudent(user) {
+    return user?.user?.role === "student";
+  }
+
+  // 獲取用戶適合的課程API
+  getCoursesFetcher(user) {
+    if (this.isInstructor(user)) {
+      return courseService.getInstructorCourses;
+    }
+    return courseService.getEnrolledCourses;
+  }
+
+  // 獲取用戶角色顯示名稱
+  getRoleDisplayName(user) {
+    return this.isInstructor(user) ? "講師" : "學生";
   }
 }
 

--- a/client/src/utils/validationUtils.js
+++ b/client/src/utils/validationUtils.js
@@ -1,7 +1,7 @@
 export const validateWithSchema = (schema, data) => {
-  const { error } = schema.validate(data, { abortEarly: false });
 
-  if (!error) return { isValid: true, errors: {} };
+  const { error, value } = schema.validate(data, { abortEarly: false });
+  if (!error) return { isValid: true, errors: {}, value };
 
   const formattedErrors = {};
   error.details.forEach((detail) => {
@@ -12,5 +12,5 @@ export const validateWithSchema = (schema, data) => {
     }
   });
 
-  return { isValid: false, errors: formattedErrors };
+  return { isValid: false, errors: formattedErrors ,value};
 };

--- a/client/src/validation/schemas/registerSchema.js
+++ b/client/src/validation/schemas/registerSchema.js
@@ -34,7 +34,7 @@ const registerSchema = Joi.object({
     then: Joi.string().min(4).required().messages({
       "any.required": "講師邀請碼為必填",
     }),
-    otherwise: Joi.forbidden(), 
+    otherwise: Joi.any().strip(), // 學生時自動移除欄位
   }),
   terms: Joi.valid(true).required().messages({
     "any.only": "您必須同意條款才能註冊",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,42 +3,45 @@ const { registerValidation, loginValidation } = require("../validation");
 const User = require("../models").user;
 const jwt = require("jsonwebtoken");
 
-// helper function for error response
+// 統一回傳錯誤
 const returnError = (res, status, msg) =>
   res.status(status).json({ success: false, message: msg });
 
+// Helpers
+const normalizeEmail = (email) => (email || "").trim().toLowerCase();
+
 router.post("/register", async (req, res) => {
   try {
-    // 確認註冊資訊是否符合規範
-    const { error } = registerValidation(req.body);
+    // 1) 驗證 + 清洗（吃到 schema 的 .strip()；並剝掉 schema 之外的鍵）
+    const { error, value } = registerValidation(req.body, {
+      abortEarly: false,
+      stripUnknown: true,
+    });
     if (error) return returnError(res, 400, error.details[0].message);
 
-    // 確認信箱是否被註冊過
-    const emailExist = await User.findOne({ email: req.body.email });
+    // 2) 一律用「驗證/清洗後」的值，避免髒欄位滲入
+    let { username, email, password, role, inviteCode } = value;
+    email = normalizeEmail(email);
+
+    // 3) Email 不可重複
+    const emailExist = await User.findOne({ email });
     if (emailExist) return returnError(res, 400, "此信箱已註冊過");
 
-    // 創立新帳號
-    let { username, email, password, role, inviteCode } = req.body;
-
-    // 只有講師需要驗證邀請碼
+    // 4) 僅講師需要驗證邀請碼（schema 已確保講師必填、學生 strip）
     if (role === "instructor") {
       const inviteFromClient = (inviteCode || "").trim();
       const expected = process.env.INSTRUCTOR_INVITE_CODE;
       if (!expected) {
-        // 安全預設：若環境沒設定邀請碼，禁止建立講師
-        return res
-          .status(500)
-          .json({ success: false, message: "發生未設定錯誤，請聯繫管理員" });
+        return returnError(res, 500, "發生未設定錯誤，請聯繫管理員");
       }
       if (inviteFromClient !== expected) {
-        return res
-          .status(403)
-          .json({ success: false, message: "講師邀請碼錯誤或已失效" });
+        return returnError(res, 403, "講師邀請碼錯誤或已失效");
       }
     }
 
-    let newUser = new User({ username, email, password, role });
-    let savedUser = await newUser.save();
+    // 5) 建立使用者（以「清洗且正規化」的 email 落庫）
+    const newUser = new User({ username, email, password, role });
+    const savedUser = await newUser.save();
 
     return res.status(201).json({
       success: true,
@@ -50,32 +53,31 @@ router.post("/register", async (req, res) => {
   }
 });
 
-//登入 製作webtoken
+// 登入：同樣只用驗證後的 value
 router.post("/login", async (req, res) => {
   try {
-    // 確認數據是否符合規範
-    const { error } = loginValidation(req.body);
-    if (error) {
-      return returnError(res, 400, error.details[0].message);
-    }
+    const { error, value } = loginValidation(req.body, {
+      abortEarly: false,
+      stripUnknown: true,
+    });
+    if (error) return returnError(res, 400, error.details[0].message);
 
-    // 確認信箱是否被註冊過
-    const foundUser = await User.findOne({ email: req.body.email });
+    const email = normalizeEmail(value.email);
+    const password = value.password;
+
+    const foundUser = await User.findOne({ email });
     if (!foundUser) {
       return returnError(res, 401, "無法找到使用者，請確認信箱是否正確");
     }
 
-    // 比較密碼
-    const isMatch = await foundUser.comparePassword(req.body.password);
+    const isMatch = await foundUser.comparePassword(password);
     if (!isMatch) return returnError(res, 401, "密碼錯誤");
 
-    // 將JWT payload 加上 role
     const tokenObject = {
       _id: foundUser._id,
       email: foundUser.email,
       role: foundUser.role,
     };
-
     const token = jwt.sign(tokenObject, process.env.PASSPORT_SECRET, {
       expiresIn: "1d",
     });

--- a/validation/index.js
+++ b/validation/index.js
@@ -2,8 +2,14 @@ const registerSchema = require("./schemas/registerSchema");
 const loginSchema = require("./schemas/loginSchema");
 const courseSchema = require("./schemas/courseSchema");
 
+// 預設：一次回報所有錯誤、剝掉 schema 之外的鍵；允許呼叫端覆蓋
+const withPrefs = (schema, data, options = {}) =>
+  schema.validate(data, { abortEarly: false, stripUnknown: true, ...options });
+
+// 封裝：一次回報所有錯誤、剝掉 schema 之外的鍵；允許呼叫端覆蓋
 module.exports = {
-  registerValidation: (data) => registerSchema.validate(data),
-  loginValidation: (data) => loginSchema.validate(data),
-  courseValidation: (data) => courseSchema.validate(data),
+  registerValidation: (data, options) =>
+    withPrefs(registerSchema, data, options),
+  loginValidation: (data, options) => withPrefs(loginSchema, data, options),
+  courseValidation: (data, options) => withPrefs(courseSchema, data, options),
 };

--- a/validation/schemas/loginSchema.js
+++ b/validation/schemas/loginSchema.js
@@ -6,13 +6,15 @@ const loginSchema = Joi.object({
     .max(50)
     .required()
     .email({ tlds: { allow: false } })
+    .trim()
+    .lowercase()
     .messages({
       "string.empty": "電子郵件為必填",
       "string.email": "請輸入有效的電子郵件地址",
     }),
   password: Joi.string().min(6).max(255).required().messages({
     "string.empty": "密碼為必填",
-    "string.min": "密碼長度至少為8個字符",
+    "string.min": "密碼長度至少為6個字符",
   }),
 });
 

--- a/validation/schemas/registerSchema.js
+++ b/validation/schemas/registerSchema.js
@@ -9,6 +9,8 @@ const registerSchema = Joi.object({
 
   email: Joi.string()
     .email({ tlds: { allow: false } })
+    .trim()
+    .lowercase()
     .required()
     .messages({
       "string.empty": "電子郵件為必填",
@@ -20,8 +22,8 @@ const registerSchema = Joi.object({
     .required()
     .messages({
       "string.empty": "密碼為必填",
-      "string.pattern.base":
-        "密碼需包含大小寫、數字與特殊符號，且長度至少6字元",
+     // 與 regex 對齊：英文字母 + 數字，長度至少 6
+     "string.pattern.base": "密碼需包含英文字母與數字，且長度至少 6 個字元",
     }),
 
   role: Joi.string().valid("student", "instructor").required().messages({
@@ -34,12 +36,13 @@ const registerSchema = Joi.object({
       .min(4)
       .required()
       .messages({ "any.required": "講師邀請碼為必填" }),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
 
   terms: Joi.valid(true).required().messages({
     "any.only": "您必須同意條款才能註冊",
   }),
+  // 若後續後端不打算用 terms，可註銷，配合 stripUnknown:true 會自動丟掉
 });
 
 module.exports = registerSchema;


### PR DESCRIPTION
本 PR 強化驗證與清洗：

- 後端 validation：回傳 {error,value}，預設 abortEarly:false、stripUnknown:true
- registerSchema：學生情境移除 inviteCode（when(...).strip()），講師仍必填
- routes/auth.js：路由全程使用驗證後的 value（不再解構 req.body）；email 正規化後查詢/落庫
- 前端：validationUtils 回傳 value；RegisterPage 送出經 Joi 清洗後的 payload（學生不再帶空的 inviteCode）

### 驗收
1) 學生註冊：即使前端帶 inviteCode:"" → 201，DB 不含 inviteCode
2) 講師註冊：缺碼 400；錯碼 403；正確 201
3) 登入：email 大小寫/前後空白可登入（normalize 生效）
4) 加多餘鍵（terms/debug）→ stripUnknown 移除，不影響流程
5) Network：學生請求不再出現 inviteCode
