### PR TITLE
register: improve inviteCode UX + zh-TW validation messages

### DIFF
--- a/client/src/components/layout/Nav.js
+++ b/client/src/components/layout/Nav.js
@@ -1,16 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import AuthService from "../../services/auth.service";
-import { formatCountdown } from "../../utils/timeUtils";
 import logo from "../../assets/logo.png";
 import "../../styles/main.css";
+// import { formatCountdown } from "../../utils/timeUtils";
 
 const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
   const [showBanner, setShowBanner] = useState(true);
-  const [countdownTime, setCountdownTime] = useState(10800);
   const navigate = useNavigate();
   const [keyword, setKeyword] = useState("");
   const location = useLocation();
+  // const [countdownTime, setCountdownTime] = useState(10800);
 
   // 若離開 /enroll，就重設 Nav 的輸入框，避免殘留文字
   useEffect(() => {
@@ -33,13 +33,13 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
     showAlert("搜尋中…", "", "elegant", 600);
   };
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCountdownTime((prevTime) => prevTime - 1);
-    }, 1000);
+  // useEffect(() => {
+  //   const interval = setInterval(() => {
+  //     setCountdownTime((prevTime) => prevTime - 1);
+  //   }, 1000);
 
-    return () => clearInterval(interval);
-  }, []);
+  //   return () => clearInterval(interval);
+  // }, []);
 
   return (
     <div className="shadow nav-position">

--- a/client/src/pages/RegisterPage.js
+++ b/client/src/pages/RegisterPage.js
@@ -32,6 +32,17 @@ const RegisterPage = ({ showAlert }) => {
     document.getElementById("username-input")?.focus();
   }, []);
 
+  // 角色切換時的清理
+  useEffect(() => {
+    if (formData.role !== "instructor") {
+      setFormData((p) => ({ ...p, inviteCode: "" }));
+      setErrors((p) => {
+        const { inviteCode, ...rest } = p || {};
+        return rest;
+      });
+    }
+  }, [formData.role]);
+
   const passwordStrength = (password) => {
     let strength = 0;
     if (password.length >= 8) strength++;
@@ -50,7 +61,17 @@ const RegisterPage = ({ showAlert }) => {
       formData
     );
     setErrors(errors);
-    if (!isValid) return;
+    console.log("registerSchema validation result:", {
+      isValid,
+      errors,
+      value,
+    });
+    if (!isValid) {
+      if (formData.role === "instructor" && errors.inviteCode) {
+        document.getElementById("invite-input")?.focus();
+      }
+      return;
+    }
 
     setIsLoading(true);
     setServerError("");
@@ -180,6 +201,7 @@ const RegisterPage = ({ showAlert }) => {
               <div className="mt-3">
                 <label className="form-label">講師授權碼</label>
                 <input
+                  id="invite-input"
                   type="password"
                   className={`form-control ${
                     errors.inviteCode ? "is-invalid" : ""
@@ -197,9 +219,6 @@ const RegisterPage = ({ showAlert }) => {
                   僅授權人員可成為講師
                 </div>
               </div>
-            )}
-            {errors.inviteCode && (
-              <div className="invalid-feedback">{errors.inviteCode}</div>
             )}
           </div>
 

--- a/client/src/validation/schemas/registerSchema.js
+++ b/client/src/validation/schemas/registerSchema.js
@@ -31,8 +31,10 @@ const registerSchema = Joi.object({
 
   inviteCode: Joi.when("role", {
     is: "instructor",
-    then: Joi.string().min(4).required().messages({
-      "any.required": "講師邀請碼為必填",
+    then: Joi.string().min(4).required().label("講師授權碼").messages({
+      "string.empty": "{{#label}}為必填",
+      "any.required": "{{#label}}為必填",
+      "string.min": "{{#label}}至少 {{#limit}} 碼",
     }),
     otherwise: Joi.any().strip(), // 學生時自動移除欄位
   }),

--- a/validation/schemas/registerSchema.js
+++ b/validation/schemas/registerSchema.js
@@ -22,8 +22,8 @@ const registerSchema = Joi.object({
     .required()
     .messages({
       "string.empty": "密碼為必填",
-     // 與 regex 對齊：英文字母 + 數字，長度至少 6
-     "string.pattern.base": "密碼需包含英文字母與數字，且長度至少 6 個字元",
+      // 與 regex 對齊：英文字母 + 數字，長度至少 6
+      "string.pattern.base": "密碼需包含英文字母與數字，且長度至少 6 個字元",
     }),
 
   role: Joi.string().valid("student", "instructor").required().messages({
@@ -32,11 +32,12 @@ const registerSchema = Joi.object({
   }),
   inviteCode: Joi.when("role", {
     is: "instructor",
-    then: Joi.string()
-      .min(4)
-      .required()
-      .messages({ "any.required": "講師邀請碼為必填" }),
-    otherwise: Joi.any().strip(),
+    then: Joi.string().min(4).required().label("講師授權碼").messages({
+      "string.empty": "{{#label}}為必填",
+      "any.required": "{{#label}}為必填",
+      "string.min": "{{#label}}至少 {{#limit}} 碼",
+    }),
+    otherwise: Joi.any().strip(), // 學生時自動移除欄位
   }),
 
   terms: Joi.valid(true).required().messages({


### PR DESCRIPTION
Frontend:
- Focus inviteCode input when validation fails
- Remove duplicate invalid-feedback block
- Reset inviteCode and clear errors when role changes

Validation (register):
- Localize inviteCode messages to zh-TW
  - string.empty / any.required / string.min

Why:
- Better UX for instructor flow (缺碼即時提示與聚焦)
- Consistent zh-TW error messages across inviteCode cases