### PR TITLE
refactor(auth/permissions): 引入 useAuthUser 與 PermissionService；精簡 AuthService 職責；頁面改用 hook/權限服務

### DIFF
--- a/client/src/components/course/CourseDetails.js
+++ b/client/src/components/course/CourseDetails.js
@@ -1,20 +1,21 @@
 import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import CourseService from "../../services/course.service";
-import AuthService from "../../services/auth.service";
+import useAuthUser from "../../hooks/useAuthUser";
 
 const CourseDetails = ({ course, isNearRightEdge, showAlert, currentUser }) => {
   const navigate = useNavigate();
   const [isEnrolling, setIsEnrolling] = useState(false);
+  const { uid, isStudent } = useAuthUser(currentUser);
 
   // 判斷目前使用者是否已註冊（兼容 students 可能是 id 字串或物件）
   const isEnrolled = useMemo(() => {
-    if (!currentUser || !course?.students) return false;
-    const me = currentUser.user?._id || currentUser._id;
+    if (!uid || !course?.students) return false;
+    const me = uid;
     return course.students.some(
       (s) => (typeof s === "string" ? s : s?._id) === me
     );
-  }, [course?.students, currentUser]);
+  }, [course?.students, uid]);
 
   const handleEnroll = async () => {
     // 未登入
@@ -27,7 +28,7 @@ const CourseDetails = ({ course, isNearRightEdge, showAlert, currentUser }) => {
     // if (currentUser.user?.role === "instructor")
 
     // 重構後：使用AuthService
-    if (!AuthService.canEnrollCourse(currentUser)) {
+    if (!isStudent) {
       showAlert("無法註冊", "註冊請轉換至學生身分", "elegant", 2000);
       return;
     }

--- a/client/src/components/layout/Nav.js
+++ b/client/src/components/layout/Nav.js
@@ -1,11 +1,22 @@
 import React, { useState, useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import AuthService from "../../services/auth.service";
+import useAuthUser from "../../hooks/useAuthUser";
 import logo from "../../assets/logo.png";
 import "../../styles/main.css";
 // import { formatCountdown } from "../../utils/timeUtils";
 
 const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
+  const {
+    isInstructor,
+    isStudent,
+    isLoggedIn,
+    canAccessCreateCoursePage,
+    canAccessEnrollPage,
+    username,
+    roleDisplayName,
+  } = useAuthUser(currentUser);
+
   const [showBanner, setShowBanner] = useState(true);
   const navigate = useNavigate();
   const [keyword, setKeyword] = useState("");
@@ -23,6 +34,17 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
     setCurrentUser(null);
     navigate("/");
   };
+
+  // 調試信息（開發環境）
+  if (process.env.NODE_ENV === "development") {
+    console.log("Nav Debug:", {
+      currentUser,
+      isInstructor,
+      isStudent,
+      isLoggedIn,
+      canAccessCreateCoursePage,
+    });
+  }
 
   const submitSearchFromNav = (e) => {
     e.preventDefault();
@@ -88,7 +110,6 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
             {/* 相對定位容器 */}
             <div className=" position-relative w-100">
               {/* 放大鏡：absolute；貼在輸入框左側 */}
-
               <button
                 type="submit"
                 className="btn p-0 border-0 bg-transparent position-absolute top-50"
@@ -99,7 +120,6 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
 
               {/* 圓角輸入框：ps-5 讓文字不壓到 icon */}
               <input
-                // className="form-control rounded-pill border-light shadow-none ps-5"
                 className="form-control search-input ps-5"
                 type="search"
                 placeholder="搜尋課程、講師或關鍵字"
@@ -126,16 +146,20 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
                 <>
                   <NavItem to="/" text="首頁" />
                   <NavItem to="/course" text="課程頁面" />
-                   {/* 重構前：直接檢查角色
+                  {/* 重構前：直接檢查角色
                    {currentUser.user.role === "instructor" && (<NavItem to="/CreateCourse" text="新增課程" />)}
                   
-                   重構後：使用AuthService */}
+                  第一階段重構後：使用AuthService */}
+                  {/* {AuthService.canCreateCourse(currentUser) && ( */}
+                  {/* 最終版: 使用明確的權限檢查 */}
                   {/* 講師才能新增課程 */}
-                  {AuthService.canCreateCourse(currentUser) && (
+                  {canAccessCreateCoursePage && (
                     <NavItem to="/CreateCourse" text="新增課程" />
                   )}
+                  {/* 第一階段重構後：使用AuthService */}
+                  {/* {AuthService.canEnrollCourse(currentUser) && ( */}
                   {/* 學生才能註冊課程 */}
-                  {AuthService.canEnrollCourse(currentUser) && (
+                  {canAccessEnrollPage && (
                     <NavItem to="/enroll" text="註冊課程" />
                   )}
                   <NavItem to="/profile" text="個人頁面" />
@@ -144,21 +168,21 @@ const NavComponent = ({ currentUser, setCurrentUser, showAlert }) => {
                       onClick={handleLogout}
                       className="nav-link btn btn-link"
                     >
-                      <span className="hover-text-primary">登出</span>
+                      登出 ({username} - {roleDisplayName})
                     </button>
                   </li>
                 </>
               ) : (
                 <>
                   <NavItem
-                    to="/login"
-                    text="登入"
-                    className="nav-login-link "
-                  />
-                  <NavItem
                     to="/register"
                     text="註冊"
                     className="nav-register-link"
+                  />
+                  <NavItem
+                    to="/login"
+                    text="登入"
+                    className="nav-login-link "
                   />
                 </>
               )}

--- a/client/src/hooks/useAuthUser.js
+++ b/client/src/hooks/useAuthUser.js
@@ -1,0 +1,91 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import AuthService from "../services/auth.service";
+import PermissionService from "../services/permission.service";
+
+export default function useAuthUser(explicitUserLike) {
+  // 狀態管理
+  const [raw, setRaw] = useState(
+    explicitUserLike ?? AuthService.getCurrentUser()
+  );
+
+  // 當 explicitUserLike 改變時，更新 raw
+  useEffect(() => {
+    if (explicitUserLike !== undefined) {
+      setRaw(explicitUserLike);
+    }
+  }, [explicitUserLike]);
+
+  // 使用 PermissionService 獲取用戶信息和權限
+  const userInfo = useMemo(() => {
+    return PermissionService.getUserInfo(raw);
+  }, [raw]);
+
+  const permissions = useMemo(() => {
+    return PermissionService.getPermissions(raw);
+  }, [raw]);
+
+  // 業務邏輯方法
+  const businessLogic = useMemo(() => {
+    return {
+      // 課程獲取
+      getCoursesFetcher: () => PermissionService.getCoursesFetcher(raw),
+      
+      // 課程操作權限檢查
+      getCourseActions: (course) => PermissionService.getCourseActions(raw, course),
+      
+      // 角色檢查方法
+      hasRole: (role) => PermissionService.hasRole(raw, role),
+      
+      // 功能權限檢查
+      canCreateCourse: () => PermissionService.canCreateCourse(raw),
+      canEnrollCourse: () => PermissionService.canEnrollCourse(raw),
+      canEditCourse: (course) => PermissionService.canEditCourse(raw, course),
+      canDropCourse: () => PermissionService.canDropCourse(raw),
+    };
+  }, [raw]);
+
+  // 控制方法
+  const refresh = useCallback(() => {
+    const currentUser = AuthService.getCurrentUser();
+    setRaw(currentUser);
+  }, []);
+
+  const updateUser = useCallback((newUserData) => {
+    setRaw(newUserData);
+  }, []);
+
+  // 跨分頁同步：監聽 localStorage 的變化
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key === "user") {
+        try {
+          setRaw(e.newValue ? JSON.parse(e.newValue) : null);
+        } catch {
+          setRaw(null);
+        }
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return {
+    // 用戶基本信息
+    ...userInfo,
+    user: PermissionService.normalizeUser(raw),
+    
+    // 權限信息
+    ...permissions,
+    
+    // 業務邏輯方法
+    ...businessLogic,
+    
+    // 控制方法
+    refresh,
+    updateUser,
+    setRaw, // 保留向後兼容
+    
+    // 原始數據（調試用）
+    rawUser: raw,
+  };
+}

--- a/client/src/pages/CoursePage.js
+++ b/client/src/pages/CoursePage.js
@@ -5,17 +5,15 @@ import CourseSkeleton from "../components/course/CourseSkeleton";
 import CreateCourseDesktop from "../assets/CreateCourse-desktop-v1.jpg";
 import CreateCourseMobile from "../assets/CreateCourse-mobile-v2.jpg";
 import EditCourseModal from "../components/course/EditCourseModal.jsx";
-import AuthService from "../services/auth.service";
+import useAuthUser from "../hooks/useAuthUser";
 
+/* ── 子元件：課程圖片 ───────────────────────── */
 const CourseImage = ({ course, width = "16rem", height = "11rem" }) => {
   const defaultImage = "https://i.ibb.co/BKqMHq0/logo.png";
-
   const [imgSrc, setImgSrc] = useState(course.image || defaultImage);
 
   const handleImageError = () => {
-    if (imgSrc !== defaultImage) {
-      setImgSrc(defaultImage);
-    }
+    if (imgSrc !== defaultImage) setImgSrc(defaultImage);
   };
 
   return (
@@ -24,42 +22,43 @@ const CourseImage = ({ course, width = "16rem", height = "11rem" }) => {
       alt="課程圖片"
       onError={handleImageError}
       className="img-fluid"
-      style={{
-        width,
-        height,
-        objectFit: "cover",
-      }}
+      style={{ width, height, objectFit: "cover" }}
     />
   );
 };
 
+/* ── 主頁面 ─────────────────────────────────── */
 const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
   const navigate = useNavigate();
   const [courseData, setCourseData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [editingCourse, setEditingCourse] = useState(null);
 
-  const handleTakeToLogin = () => {
-    navigate("/login");
-  };
+  // 使用 Hook 取得所有需要的信息和方法
+  const {
+    uid,
+    isInstructor,
+    isStudent,
+    isLoggedIn,
+    roleDisplayName,
+    getCoursesFetcher,
+    getCourseActions,
+    canEditCourse
+  } = useAuthUser(currentUser);
 
-  const handleTakeToCreateCourse = () => {
-    navigate("/CreateCourse");
-  };
+  /* ── 導頁方法 ─────────────────────────────── */
+  const handleTakeToLogin = () => navigate("/login");
+  const handleTakeToCreateCourse = () => navigate("/CreateCourse");
+  const handleTakeToEnroll = () => navigate("/enroll");
 
-  const handleTakeToEnroll = () => {
-    navigate("/enroll");
-  };
-
+  /* ── 課程操作方法 ─────────────────────────── */
   const handleDelete = (e) => {
     const courseId = e.target.id;
     if (window.confirm("確定要刪除這個課程嗎？")) {
       CourseService.delete(courseId)
         .then(() => {
           showAlert("已刪除課程", "課程已成功刪除。", "elegant", 1000);
-          setCourseData((prevData) =>
-            prevData.filter((course) => course._id !== courseId)
-          );
+          setCourseData((prev) => prev.filter((c) => c._id !== courseId));
         })
         .catch((err) => {
           console.error("刪除課程失敗:", err.message);
@@ -79,9 +78,7 @@ const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
             "elegant",
             1000
           );
-          setCourseData((prevData) =>
-            prevData.filter((course) => course._id !== courseId)
-          );
+          setCourseData((prev) => prev.filter((c) => c._id !== courseId));
         })
         .catch((err) => {
           console.error("退選課程時發生錯誤:", err.message);
@@ -91,11 +88,8 @@ const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
   };
 
   const handleEdit = (course) => {
-    // 防止資料不完整時發生錯誤
-    if (
-      !course.instructor ||
-      course.instructor._id !== currentUser?.user?._id
-    ) {
+    // 使用 Hook 提供的權限檢查方法
+    if (!canEditCourse(course)) {
       showAlert("權限錯誤", "只有課程講師才能編輯課程", "error", 1500);
       return;
     }
@@ -105,12 +99,11 @@ const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
   const handleUpdate = async (courseId, updatedData) => {
     try {
       const response = await CourseService.update(courseId, updatedData);
-      // 更新本地課程數據
-      setCourseData((prevData) =>
-        prevData.map((course) =>
-          course._id === courseId
-            ? { ...course, ...updatedData, instructor: course.instructor }
-            : course
+      setCourseData((prev) =>
+        prev.map((c) =>
+          c._id === courseId
+            ? { ...c, ...updatedData, instructor: c.instructor }
+            : c
         )
       );
       return response;
@@ -119,191 +112,203 @@ const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
     }
   };
 
-  // 修改課程卡片中的編輯按鈕渲染邏輯
+  // 課程操作按鈕渲染（使用權限檢查）
   const renderCourseActions = (course) => {
-    if (AuthService.canEditCourse(currentUser, course)) {
+    const actions = getCourseActions(course);
+    
+    if (actions.canEdit || actions.canDelete) {
       return (
         <div className="d-flex justify-content-between align-items-center">
-          <button onClick={() => handleEdit(course)} className="btn btn-outline-secondary btn-sm px-3">
-            編輯課程
-          </button>
-          <button id={course._id} onClick={handleDelete} className="btn btn-outline-danger btn-sm px-3">
-            刪除課程
-          </button>
+          {actions.canEdit && (
+            <button
+              onClick={() => handleEdit(course)}
+              className="btn btn-outline-secondary btn-sm px-3"
+            >
+              編輯課程
+            </button>
+          )}
+          {actions.canDelete && (
+            <button
+              id={course._id}
+              onClick={handleDelete}
+              className="btn btn-outline-danger btn-sm px-3"
+            >
+              刪除課程
+            </button>
+          )}
         </div>
       );
-    } else if (AuthService.canDropCourse(currentUser)) {
+    }
+
+    if (actions.canDrop) {
       return (
         <div className="d-flex justify-content-center">
-          <button id={course._id} onClick={handleDrop} className="btn btn-outline-danger rounded-0">
+          <button
+            id={course._id}
+            onClick={handleDrop}
+            className="btn btn-outline-danger rounded-0"
+          >
             退選課程
           </button>
         </div>
       );
     }
+
     return null;
   };
 
+  /* ── 課程數據獲取 ─────────────────────────── */
   useEffect(() => {
-    if (currentUser) {
-      const _id = currentUser.user._id;
-      const fetchCourses = AuthService.getCoursesFetcher(currentUser);
-      
-      fetchCourses(_id)
-        .then((data) => {
-          setCourseData(data);
-          setIsLoading(false);
-        })
-        .catch((e) => {
-          console.log(e);
-          setIsLoading(false);
-        });
-    } else {
+    if (!isLoggedIn) {
       setIsLoading(false);
+      return;
     }
-  }, [currentUser]);
 
+    // 使用 Hook 提供的課程獲取方法
+    const fetchCourses = getCoursesFetcher();
+
+    fetchCourses(uid)
+      .then((data) => {
+        setCourseData(data);
+        setIsLoading(false);
+      })
+      .catch((e) => {
+        console.error(e);
+        setIsLoading(false);
+      });
+  }, [uid, isLoggedIn, getCoursesFetcher]);
+
+  /* ── Loading 狀態 ─────────────────────────── */
   if (isLoading) {
     return (
       <div>
-        {currentUser && (
+        {isLoggedIn && (
           <div className="mb-3">
-            <h1>
-              歡迎來到{currentUser.user.role === "instructor" ? "講師" : "學生"}
-              的課程頁面
-            </h1>
+            <h1>歡迎來到{roleDisplayName}的課程頁面</h1>
           </div>
         )}
-        <div>
-          <CourseSkeleton />
+        <CourseSkeleton />
+      </div>
+    );
+  }
+
+  /* ── 未登入狀態 ───────────────────────────── */
+  if (!isLoggedIn) {
+    return (
+      <div style={{ padding: "3rem" }}>
+        <div className="banner-container">
+          <div className="w-100">
+            <picture>
+              <source
+                srcSet={CreateCourseMobile}
+                width="650"
+                height="416"
+                media="(max-width: 768px)"
+                loading="lazy"
+              />
+              <img
+                className="w-100 img-fluid"
+                alt="Banner"
+                src={CreateCourseDesktop}
+                loading="lazy"
+              />
+            </picture>
+          </div>
+
+          <div className="text-container bg-light p-4 mx-5 d-flex flex-column">
+            <h3 className="mb-3">必須要先登入才能看到課程。</h3>
+            <button
+              className="btn btn-dark rounded-0 w-100"
+              onClick={handleTakeToLogin}
+            >
+              回到登入頁面
+            </button>
+          </div>
         </div>
       </div>
     );
   }
 
+  /* ── 已登入狀態 ───────────────────────────── */
   return (
     <div style={{ padding: "3rem" }}>
-      {!currentUser && (
-        <div>
-          <div className="banner-container">
-            <div className="w-100">
-              <picture>
-                <source
-                  srcSet={CreateCourseMobile}
-                  width="650"
-                  height="416"
-                  media="(max-width: 768px)"
-                  loading="lazy"
-                ></source>
+      <div className="container mb-4">
+        <h1 className="mb-2 text-start">
+          歡迎來到{roleDisplayName}的課程頁面
+        </h1>
+        <h5 className="text-muted bg-gray-100 py-3">以下是您目前的課程清單:</h5>
+      </div>
 
-                <img
-                  className="w-100 img-fluid"
-                  alt="Banner"
-                  src={CreateCourseDesktop}
-                  loading="lazy"
-                ></img>
-              </picture>
-            </div>
+      {/* 空清單（講師） */}
+      {isInstructor && courseData.length === 0 && (
+        <div className="banner-container">
+          <div className="w-100">
+            <picture>
+              <source
+                srcSet={CreateCourseMobile}
+                width="650"
+                height="416"
+                media="(max-width: 768px)"
+                loading="lazy"
+              />
+              <img
+                className="w-100 img-fluid"
+                alt="Banner"
+                src={CreateCourseDesktop}
+                loading="lazy"
+              />
+            </picture>
+          </div>
 
-            <div className="text-container bg-light p-4  mx-5 d-flex align-items-cente flex-column">
-              <h3 className="mb-3 ">必須要先登入才能看到課程。</h3>
-              {/* <p className="mb-4">點擊下方，建立課程</p> */}
-              <button
-                className="btn  btn-dark rounded-0 w-100 "
-                onClick={handleTakeToLogin}
-              >
-                回到登入頁面
-              </button>
-            </div>
+          <div className="text-container bg-light p-4 mx-5">
+            <h2 className="mb-3">尚未上傳課程</h2>
+            <p className="mb-4">點擊下方，建立課程</p>
+            <button
+              className="btn btn-dark rounded-0 w-100"
+              onClick={handleTakeToCreateCourse}
+            >
+              立即開始
+            </button>
           </div>
         </div>
       )}
 
-      {currentUser && (
-        <div className="container mb-4">
-          <h1 className="mb-2 text-start">
-            歡迎來到{currentUser.user.role === "instructor" ? "講師" : "學生"}
-            的課程頁面
-          </h1>
-          <h5 className="text-muted bg-gray-100 py-3">
-            以下是您目前的課程清單:
-          </h5>
+      {/* 空清單（學生） */}
+      {isStudent && courseData.length === 0 && (
+        <div className="banner-container">
+          <div className="w-100">
+            <picture>
+              <source
+                srcSet={CreateCourseMobile}
+                width="650"
+                height="416"
+                media="(max-width: 768px)"
+                loading="lazy"
+              />
+              <img
+                className="w-100 img-fluid"
+                alt="Banner"
+                src={CreateCourseDesktop}
+                loading="lazy"
+              />
+            </picture>
+          </div>
+
+          <div className="text-container bg-light p-4 mx-5">
+            <h2 className="mb-3">尚未註冊課程</h2>
+            <p className="mb-4">點擊下方，開始學習</p>
+            <button
+              className="btn btn-dark rounded-0 w-100"
+              onClick={handleTakeToEnroll}
+            >
+              立即開始
+            </button>
+          </div>
         </div>
       )}
 
-      {currentUser &&
-        currentUser.user.role === "instructor" &&
-        courseData.length === 0 && (
-          <div className="banner-container">
-            <div className="w-100">
-              <picture>
-                <source
-                  srcSet={CreateCourseMobile}
-                  width="650"
-                  height="416"
-                  media="(max-width: 768px)"
-                  loading="lazy"
-                ></source>
-
-                <img
-                  className="w-100 img-fluid"
-                  alt="Banner"
-                  src={CreateCourseDesktop}
-                  loading="lazy"
-                ></img>
-              </picture>
-            </div>
-
-            <div className="text-container bg-light p-4 mx-5">
-              <h2 className="mb-3 ">尚未上傳課程</h2>
-              <p className="mb-4">點擊下方，建立課程</p>
-              <button
-                className="btn  btn-dark rounded-0 w-100 "
-                onClick={handleTakeToCreateCourse}
-              >
-                立即開始
-              </button>
-            </div>
-          </div>
-        )}
-
-      {currentUser &&
-        currentUser.user.role === "student" &&
-        courseData.length === 0 && (
-          <div className="banner-container">
-            <div className="w-100">
-              <picture>
-                <source
-                  srcSet={CreateCourseMobile}
-                  width="650"
-                  height="416"
-                  media="(max-width: 768px)"
-                  loading="lazy"
-                ></source>
-
-                <img
-                  className="w-100 img-fluid"
-                  alt="Banner"
-                  src={CreateCourseDesktop}
-                  loading="lazy"
-                ></img>
-              </picture>
-            </div>
-
-            <div className="text-container bg-light p-4 mx-5">
-              <h2 className="mb-3 ">尚未註冊課程</h2>
-              <p className="mb-4">點擊下方，開始學習</p>
-              <button
-                className="btn  btn-dark rounded-0 w-100 "
-                onClick={handleTakeToEnroll}
-              >
-                立即開始
-              </button>
-            </div>
-          </div>
-        )}
-
-      {currentUser && courseData.length > 0 && (
+      {/* 課程列表 */}
+      {courseData.length > 0 && (
         <div className="container">
           <div className="row">
             {courseData.map((course) => (
@@ -312,7 +317,7 @@ const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
                 className="col-12 col-sm-6 col-md-4 col-lg-3 mb-4"
               >
                 <div
-                  className="card h-100 border-0 shadow-sm "
+                  className="card h-100 border-0 shadow-sm"
                   style={{
                     transition: "all 0.3s ease-in-out",
                     cursor: "pointer",
@@ -363,4 +368,5 @@ const CoursePage = ({ currentUser, setCurrentUser, showAlert }) => {
     </div>
   );
 };
+
 export default CoursePage;

--- a/client/src/services/auth.service.js
+++ b/client/src/services/auth.service.js
@@ -1,18 +1,20 @@
 import axios from "axios";
-import courseService from "./course.service";
 
 const API_URL = `${process.env.REACT_APP_API_BASE_URL}/api/user`;
 
 class AuthService {
+  // 核心認證功能
   login(email, password) {
     return axios.post(`${API_URL}/login`, {
       email,
       password,
     });
   }
+  
   logout() {
     localStorage.removeItem("user");
   }
+  
   register(formData) {
     return axios.post(`${API_URL}/register`, formData);
   }
@@ -21,45 +23,14 @@ class AuthService {
     return JSON.parse(localStorage.getItem("user"));
   }
 
-  // 🆕 權限檢查方法
-  canCreateCourse(user) {
-    return user?.user?.role === "instructor";
+  // 設置當前用戶（登入後使用）
+  setCurrentUser(userData) {
+    localStorage.setItem("user", JSON.stringify(userData));
   }
 
-  canEnrollCourse(user) {
-    return user?.user?.role === "student";
-  }
-
-  canEditCourse(user, course) {
-    return (
-      user?.user?.role === "instructor" &&
-      course?.instructor?._id === user?.user?._id
-    );
-  }
-
-  canDropCourse(user) {
-    return user?.user?.role === "student";
-  }
-
-  isInstructor(user) {
-    return user?.user?.role === "instructor";
-  }
-
-  isStudent(user) {
-    return user?.user?.role === "student";
-  }
-
-  // 獲取用戶適合的課程API
-  getCoursesFetcher(user) {
-    if (this.isInstructor(user)) {
-      return courseService.getInstructorCourses;
-    }
-    return courseService.getEnrolledCourses;
-  }
-
-  // 獲取用戶角色顯示名稱
-  getRoleDisplayName(user) {
-    return this.isInstructor(user) ? "講師" : "學生";
+  // 檢查是否已登入
+  isAuthenticated() {
+    return !!this.getCurrentUser();
   }
 }
 

--- a/client/src/services/permission.service.js
+++ b/client/src/services/permission.service.js
@@ -1,0 +1,169 @@
+import CourseService from './course.service';
+
+class PermissionService {
+  // 核心權限檢查方法
+  static hasRole(user, role) {
+    if (!user) return false;
+    const normalizedUser = this.normalizeUser(user);
+    return normalizedUser?.role === role;
+  }
+
+  static isInstructor(user) {
+    return this.hasRole(user, 'instructor');
+  }
+
+  static isStudent(user) {
+    return this.hasRole(user, 'student');
+  }
+
+  static isLoggedIn(user) {
+    const normalizedUser = this.normalizeUser(user);
+    return !!(normalizedUser?._id && normalizedUser?.role);
+  }
+
+  // 功能權限檢查
+  static canCreateCourse(user) {
+    return this.isInstructor(user);
+  }
+
+  static canEnrollCourse(user) {
+    return this.isStudent(user);
+  }
+
+  static canEditCourse(user, course) {
+    if (!this.isInstructor(user) || !course) return false;
+    const normalizedUser = this.normalizeUser(user);
+    return course.instructor?._id === normalizedUser?._id;
+  }
+
+  static canDropCourse(user) {
+    return this.isStudent(user);
+  }
+
+  static canViewInstructorDashboard(user) {
+    return this.isInstructor(user);
+  }
+
+  static canViewStudentDashboard(user) {
+    return this.isStudent(user);
+  }
+
+  // 導航權限
+  static canAccessCreateCoursePage(user) {
+    return this.isInstructor(user);
+  }
+
+  static canAccessEnrollPage(user) {
+    return this.isStudent(user);
+  }
+
+  static canAccessProfilePage(user) {
+    return this.isLoggedIn(user);
+  }
+
+  // 用戶數據標準化（內建）
+  static normalizeUser(userLike) {
+    if (!userLike) return null;
+    
+    // 如果是嵌套結構 { user: {...} }，提取內層
+    if (userLike.user && typeof userLike.user === 'object') {
+      return userLike.user;
+    }
+    
+    // 如果已經是扁平結構，直接返回
+    if (userLike._id || userLike.id) {
+      return userLike;
+    }
+    
+    return null;
+  }
+
+  // 獲取用戶信息
+  static getUserInfo(user) {
+    const normalizedUser = this.normalizeUser(user);
+    if (!normalizedUser) {
+      return {
+        uid: null,
+        username: null,
+        email: null,
+        role: null,
+        roleDisplayName: '未登入',
+        isLoggedIn: false
+      };
+    }
+
+    return {
+      uid: normalizedUser._id,
+      username: normalizedUser.username,
+      email: normalizedUser.email,
+      role: normalizedUser.role,
+      roleDisplayName: this.getRoleDisplayName(normalizedUser.role),
+      isLoggedIn: true
+    };
+  }
+
+  static getRoleDisplayName(role) {
+    switch (role) {
+      case 'instructor': return '講師';
+      case 'student': return '學生';
+      default: return '未知';
+    }
+  }
+
+  // 批量權限檢查（性能優化）
+  static getPermissions(user) {
+    const normalizedUser = this.normalizeUser(user);
+    const isInstructor = this.isInstructor(normalizedUser);
+    const isStudent = this.isStudent(normalizedUser);
+    const isLoggedIn = this.isLoggedIn(normalizedUser);
+
+    return {
+      // 角色檢查
+      isInstructor,
+      isStudent,
+      isLoggedIn,
+      
+      // 功能權限
+      canCreateCourse: isInstructor,
+      canEnrollCourse: isStudent,
+      canDropCourse: isStudent,
+      canViewInstructorDashboard: isInstructor,
+      canViewStudentDashboard: isStudent,
+      
+      // 頁面訪問權限
+      canAccessCreateCoursePage: isInstructor,
+      canAccessEnrollPage: isStudent,
+      canAccessProfilePage: isLoggedIn,
+    };
+  }
+
+  // 新增：課程數據獲取邏輯（解決 getCoursesFetcher 問題）
+  static getCoursesFetcher(user) {
+    const normalizedUser = this.normalizeUser(user);
+    
+    if (this.isInstructor(normalizedUser)) {
+      return (userId) => CourseService.getInstructorCourses(userId);
+    }
+    
+    if (this.isStudent(normalizedUser)) {
+      return (userId) => CourseService.getEnrolledCourses(userId);
+    }
+    
+    // 未登入或未知角色
+    return () => Promise.resolve([]);
+  }
+
+  // 新增：課程操作權限檢查
+  static getCourseActions(user, course) {
+    const normalizedUser = this.normalizeUser(user);
+    
+    return {
+      canEdit: this.canEditCourse(normalizedUser, course),
+      canDelete: this.canEditCourse(normalizedUser, course), // 同編輯權限
+      canDrop: this.isStudent(normalizedUser),
+      canEnroll: this.isStudent(normalizedUser)
+    };
+  }
+}
+
+export default PermissionService;

--- a/client/src/utils/userUtils.js
+++ b/client/src/utils/userUtils.js
@@ -1,0 +1,15 @@
+export function normalizeUser(userLike) {
+  if (!userLike) return null;
+
+  // 如果是嵌套結構 { user: {...} }，提取內層
+  if (userLike.user && typeof userLike.user === "object") {
+    return userLike.user;
+  }
+
+  // 如果已經是扁平結構，直接返回
+  if (userLike._id || userLike.id) {
+    return userLike;
+  }
+
+  return null;
+}


### PR DESCRIPTION
# 摘要

將 UI 對 `currentUser` 的直讀與手寫 `role` 判斷，收斂為**依權限顯示**的模式：
以 `PermissionService` 統一權限判斷，配合 `useAuthUser` 輸出使用者資訊、權限與**課程資料取得函式（fetcher）**；`AuthService` 回歸**身分驗證與 Session（登入狀態）管理**的單一職責，並**移除對 CourseService 的耦合**。頁面改用 hook／服務，消除 prop drilling 與重複邏輯。

---

## 變更內容

### 共用／基座

* **`src/utils/userUtils.js`**：新增 `normalizeUser(userLike)`，統一處理 `{ user: {...} }` 或扁平物件，避免各處判空與結構分歧。
* **`src/services/permission.service.js`**：集中權限檢查與頁面／資料能力

  * 角色／登入：`isInstructor`、`isStudent`、`isLoggedIn`
  * 功能權限：`canCreateCourse`、`canEnrollCourse`、`canEditCourse`、`canDropCourse`
  * 頁面權限：`canAccessCreateCoursePage`、`canAccessEnrollPage`、`canAccessProfilePage`
  * **資料取得函式（fetcher）**：`getCoursesFetcher(user)` 依角色回傳「講師課程／學生已修課」的取得函式
  * 行為聚合：`getCourseActions(user, course)`（edit／delete／drop／enroll）
* **`src/hooks/useAuthUser.js`**：以 hook 輸出**使用者資訊 + 權限 + 業務方法**與 `refresh/updateUser`，並處理跨分頁 `localStorage` 同步。

### AuthService 精簡（解耦）

* **`src/services/auth.service.js`**：保留 `login/logout/register/getCurrentUser/setCurrentUser/isAuthenticated`；**移除課程／權限相關邏輯與對 CourseService 的直接依賴**，避免職責混雜。

### 頁面遷移（依權限顯示）

* **`src/pages/CoursePage.js`**：改用 `useAuthUser()` 取得 `uid/isInstructor/isStudent/isLoggedIn` 與 `getCoursesFetcher()`、`getCourseActions(course)`；以權限輸出決定「編輯／刪除／退選」按鈕顯示與可用性。
* **`src/components/layout/Nav.js`**：改以權限顯示導覽項，不再直讀 `role`：
  `PermissionService.canCreateCourse(currentUser)`／`PermissionService.canEnrollCourse(currentUser)`

> 成果：UI 不再關心「誰是講師／學生」的字串，而是**是否具備某操作的權限**；規則集中在服務層，未來切換權限模型（RBAC → 旗標／策略／ABAC）時，頁面無須跟著大改。

---

## Files changed

* `src/utils/userUtils.js`（新增）
* `src/services/permission.service.js`（新增）
* `src/hooks/useAuthUser.js`（新增）
* `src/services/auth.service.js`（調整：移除 CourseService／權限耦合）
* `src/pages/CoursePage.js`（改用 hook／權限服務）
* `src/components/layout/Nav.js`（依權限顯示導覽項）

---

## 此次改動目的

* **解耦與單一職責**：`AuthService` 專注 **帳號與登入狀態（Session）**；權限與頁面能力集中於 `PermissionService`／`useAuthUser`。
* **消除 prop drilling**：頁面／元件自行從 hook 取資料與權限，避免多層 props 傳遞。
* **可擴充**：權限規則集中一處，未來增加新角色／旗標／策略僅改服務層。
* **一致性與可測試**：頁面只依服務輸出渲染；權限與  **資料取得函式（fetcher）** 可做單元測試，UI 做渲染與流程測試。

---

## Smoke Test

1. **講師登入**：`CoursePage` 能看到**自己的課**；僅對自己課程顯示「編輯／刪除」。`Nav` 顯示「新增課程」，不顯示「註冊課程」。
2. **學生登入**：`CoursePage` 顯示**已註冊課**且可退選；`Nav` 顯示「註冊課程」，不顯示「新增課程」。
3. **未登入**：`Nav` 無兩個課程入口；`CoursePage` 顯示登入提示。
4. **程式碼檢查**：頁面不再直接比較 `currentUser.user.role`，均改為 `useAuthUser/PermissionService` 的輸出。

---

## 風險／回滾

* 低風險：主要是呼叫點替換與服務層集中，無破壞性資料結構變更。
* 回滾路徑：

  * 服務層：revert `permission.service.js`、`useAuthUser.js`、`userUtils.js`
  * 頁面：revert `CoursePage.js`、`Nav.js`
  * `AuthService`：可獨立回滾（僅移除耦合）