### PR TITLE
fix(api): increase server payload limit for media uploads

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,8 +19,8 @@ const helmet = require('helmet');
 // ======================
 app.use(helmet());
 app.use(cors());
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // ===========================
 //  MongoDB 資料庫連線


### PR DESCRIPTION
###  **Context:** 
Users encountered `413 (Content Too Large)` errors when attempting to create courses with high-resolution cover images. This was due to the default Express body-parser limit, which did not account for the **33% size overhead** introduced by Base64 encoding.

###  **Solution:**
 Increased the `json` and `urlencoded` limits to **10MB** in `server.js`.

### **Engineering Impact:** 
Resolves deployment blockers on cloud platforms (e.g., Render) and ensures the system can reliably process media-heavy payloads while maintaining a reasonable upper bound for server resource protection.