### PR TITLE
Refactor course hover detail into viewport-aware popover

### DIFF
--- a/client/src/components/course/CourseCard.jsx
+++ b/client/src/components/course/CourseCard.jsx
@@ -3,13 +3,31 @@ import CourseImage from './CourseImage';
 import CourseDetails from './CourseDetails';
 
 const CourseCard = forwardRef(
-  ({ course, showAlert, currentUser, onCardMouseEnter, onCardMouseLeave }, ref) => {
+  (
+    {
+      course,
+      showAlert,
+      currentUser,
+      onCardMouseEnter,
+      onCardMouseMove,
+      onCardPointerDown,
+      onCardMouseLeave,
+    },
+    ref
+  ) => {
+    const handlePointerDown = (event) => {
+      if (event.target.closest?.('button, a, input, select, textarea')) return;
+      onCardPointerDown?.(course, event.currentTarget);
+    };
+
     return (
       <div
         ref={ref}
         className="card me-3 p-2 position-relative mb-4 course-card shadow-sm"
         style={{ borderRadius: '12px' }}
         onMouseEnter={(event) => onCardMouseEnter?.(course, event.currentTarget)}
+        onMouseMove={(event) => onCardMouseMove?.(course, event.currentTarget)}
+        onPointerDown={handlePointerDown}
         onMouseLeave={onCardMouseLeave}
       >
         <div className="course-imager">

--- a/client/src/components/course/CourseCard.jsx
+++ b/client/src/components/course/CourseCard.jsx
@@ -3,12 +3,14 @@ import CourseImage from './CourseImage';
 import CourseDetails from './CourseDetails';
 
 const CourseCard = forwardRef(
-  ({ course, showAlert, currentUser, isNearRightEdge }, ref) => {
+  ({ course, showAlert, currentUser, onCardMouseEnter, onCardMouseLeave }, ref) => {
     return (
       <div
         ref={ref}
         className="card me-3 p-2 position-relative mb-4 course-card shadow-sm"
         style={{ borderRadius: '12px' }}
+        onMouseEnter={(event) => onCardMouseEnter?.(course, event.currentTarget)}
+        onMouseLeave={onCardMouseLeave}
       >
         <div className="course-imager">
           <CourseImage course={course} />
@@ -36,11 +38,7 @@ const CourseCard = forwardRef(
           </div>
         </div>
 
-        <div
-          className={`course-details-wrapper ${
-            isNearRightEdge ? 'align-left' : 'align-right'
-          }`}
-        >
+        <div className="course-details-inline">
           <CourseDetails
             course={course}
             showAlert={showAlert}

--- a/client/src/components/course/CourseCardScroller.jsx
+++ b/client/src/components/course/CourseCardScroller.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { flushSync } from 'react-dom';
 import CourseService from '../../services/course.service';
 import CourseCard from './CourseCard';
 import CourseHoverPopover from './CourseHoverPopover';
@@ -11,60 +12,51 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   const [showRightArrow, setShowRightArrow] = useState(true);
   const [hoveredCourse, setHoveredCourse] = useState(null);
   const [anchorRect, setAnchorRect] = useState(null);
+  const [isPopoverClosing, setIsPopoverClosing] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const containerRef = useRef(null);
   const cardsRef = useRef([]);
   const closeTimerRef = useRef(null);
-  const anchorElementRef = useRef(null);
 
   const clearCloseTimer = useCallback(() => {
     if (closeTimerRef.current) {
       clearTimeout(closeTimerRef.current);
       closeTimerRef.current = null;
     }
+    setIsPopoverClosing(false);
   }, []);
 
   const closePopover = useCallback(() => {
     clearCloseTimer();
-    anchorElementRef.current = null;
     setHoveredCourse(null);
     setAnchorRect(null);
+    setIsPopoverClosing(false);
+  }, [clearCloseTimer]);
+
+  const closePopoverImmediately = useCallback(() => {
+    clearCloseTimer();
+    flushSync(() => {
+      setHoveredCourse(null);
+      setAnchorRect(null);
+      setIsPopoverClosing(false);
+    });
   }, [clearCloseTimer]);
 
   const scheduleClosePopover = useCallback(() => {
     clearCloseTimer();
+    setIsPopoverClosing(true);
     closeTimerRef.current = setTimeout(() => {
-      anchorElementRef.current = null;
       setHoveredCourse(null);
       setAnchorRect(null);
+      setIsPopoverClosing(false);
     }, 120);
   }, [clearCloseTimer]);
-
-  const updatePopoverPosition = useCallback(() => {
-    const anchorElement = anchorElementRef.current;
-    if (!anchorElement) return;
-
-    const nextRect = anchorElement.getBoundingClientRect();
-    const isVisible =
-      nextRect.bottom > 0 &&
-      nextRect.top < window.innerHeight &&
-      nextRect.right > 0 &&
-      nextRect.left < window.innerWidth;
-
-    if (!isVisible) {
-      closePopover();
-      return;
-    }
-
-    setAnchorRect(nextRect);
-  }, [closePopover]);
 
   const handleCardMouseEnter = useCallback(
     (course, cardElement) => {
       clearCloseTimer();
-      anchorElementRef.current = cardElement;
       setHoveredCourse(course);
       setAnchorRect(cardElement.getBoundingClientRect());
     },
@@ -81,8 +73,8 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     setShowLeftArrow(!isAtStart);
     setShowRightArrow(!isAtEnd);
 
-    updatePopoverPosition();
-  }, [updatePopoverPosition]);
+    closePopover();
+  }, [closePopover]);
 
   const scroll = useCallback(
     (direction) => {
@@ -127,18 +119,16 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     const container = containerRef.current;
     if (container) {
       container.addEventListener('scroll', checkScrollState);
-      window.addEventListener('scroll', updatePopoverPosition, {
-        passive: true,
-      });
+      window.addEventListener('scroll', closePopover, { passive: true });
       window.addEventListener('resize', checkScrollState);
       return () => {
         container.removeEventListener('scroll', checkScrollState);
-        window.removeEventListener('scroll', updatePopoverPosition);
+        window.removeEventListener('scroll', closePopover);
         window.removeEventListener('resize', checkScrollState);
         clearCloseTimer();
       };
     }
-  }, [checkScrollState, clearCloseTimer, updatePopoverPosition]);
+  }, [checkScrollState, clearCloseTimer, closePopover]);
 
   // 添加觸摸滑動支持
   useEffect(() => {
@@ -189,7 +179,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   if (courses.length === 0) return <div>目前沒有可用的課程</div>;
 
   return (
-    <div className="course-card-scroller">
+    <div className="course-card-scroller" onWheelCapture={closePopoverImmediately}>
       <ScrollButton
         direction="left"
         onClick={() => scroll('left')}
@@ -218,8 +208,10 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
         anchorRect={anchorRect}
         showAlert={showAlert}
         currentUser={currentUser}
+        isClosing={isPopoverClosing}
         onMouseEnter={clearCloseTimer}
         onMouseLeave={scheduleClosePopover}
+        onWheel={closePopoverImmediately}
       />
     </div>
   );

--- a/client/src/components/course/CourseCardScroller.jsx
+++ b/client/src/components/course/CourseCardScroller.jsx
@@ -7,7 +7,7 @@ import ScrollButton from './ScrollButton';
 import CourseSkeleton from './CourseSkeleton';
 
 const HOVER_CLOSE_GRACE_MS = 140;
-const POPOVER_EXIT_ANIMATION_MS = 120;
+const POPOVER_EXIT_ANIMATION_MS = 150;
 
 const CourseCardScroller = ({ showAlert, currentUser }) => {
   const [courses, setCourses] = useState([]);
@@ -23,6 +23,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   const cardsRef = useRef([]);
   const closeGraceTimerRef = useRef(null);
   const exitAnimationTimerRef = useRef(null);
+  const activePreviewCourseIdRef = useRef(null);
   const isPopoverOpen = Boolean(hoveredCourse && anchorRect);
 
   const clearCloseTimer = useCallback(() => {
@@ -39,6 +40,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
 
   const closePopover = useCallback(() => {
     clearCloseTimer();
+    activePreviewCourseIdRef.current = null;
     setHoveredCourse(null);
     setAnchorRect(null);
     setIsPopoverClosing(false);
@@ -46,6 +48,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
 
   const closePopoverImmediately = useCallback(() => {
     clearCloseTimer();
+    activePreviewCourseIdRef.current = null;
     flushSync(() => {
       setHoveredCourse(null);
       setAnchorRect(null);
@@ -62,18 +65,53 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
         setHoveredCourse(null);
         setAnchorRect(null);
         setIsPopoverClosing(false);
+        activePreviewCourseIdRef.current = null;
         exitAnimationTimerRef.current = null;
       }, POPOVER_EXIT_ANIMATION_MS);
     }, HOVER_CLOSE_GRACE_MS);
   }, [clearCloseTimer]);
 
+  const showCoursePreview = useCallback((course, cardElement) => {
+    activePreviewCourseIdRef.current = course._id;
+    setHoveredCourse(course);
+    setAnchorRect(cardElement.getBoundingClientRect());
+  }, []);
+
   const handleCardMouseEnter = useCallback(
     (course, cardElement) => {
       clearCloseTimer();
-      setHoveredCourse(course);
-      setAnchorRect(cardElement.getBoundingClientRect());
+      if (activePreviewCourseIdRef.current === course._id && hoveredCourse?._id === course._id) {
+        return;
+      }
+      showCoursePreview(course, cardElement);
     },
-    [clearCloseTimer]
+    [clearCloseTimer, hoveredCourse?._id, showCoursePreview]
+  );
+
+  const handleCardMouseMove = useCallback(
+    (course, cardElement) => {
+      const isSamePreview =
+        activePreviewCourseIdRef.current === course._id && hoveredCourse?._id === course._id;
+
+      if (isSamePreview && !isPopoverClosing) return;
+
+      clearCloseTimer();
+      showCoursePreview(course, cardElement);
+    },
+    [clearCloseTimer, hoveredCourse?._id, isPopoverClosing, showCoursePreview]
+  );
+
+  const handleCardPointerDown = useCallback(
+    (course, cardElement) => {
+      const isSamePreview =
+        activePreviewCourseIdRef.current === course._id && hoveredCourse?._id === course._id;
+
+      if (isSamePreview && !isPopoverClosing) return;
+
+      clearCloseTimer();
+      showCoursePreview(course, cardElement);
+    },
+    [clearCloseTimer, hoveredCourse?._id, isPopoverClosing, showCoursePreview]
   );
 
   const updateScrollButtons = useCallback(() => {
@@ -227,6 +265,8 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
             showAlert={showAlert}
             currentUser={currentUser}
             onCardMouseEnter={handleCardMouseEnter}
+            onCardMouseMove={handleCardMouseMove}
+            onCardPointerDown={handleCardPointerDown}
             onCardMouseLeave={scheduleClosePopover}
           />
         ))}

--- a/client/src/components/course/CourseCardScroller.jsx
+++ b/client/src/components/course/CourseCardScroller.jsx
@@ -19,6 +19,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   const containerRef = useRef(null);
   const cardsRef = useRef([]);
   const closeTimerRef = useRef(null);
+  const isPopoverOpen = Boolean(hoveredCourse && anchorRect);
 
   const clearCloseTimer = useCallback(() => {
     if (closeTimerRef.current) {
@@ -63,7 +64,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     [clearCloseTimer]
   );
 
-  const checkScrollState = useCallback(() => {
+  const updateScrollButtons = useCallback(() => {
     if (!containerRef.current) return;
     const container = containerRef.current;
     const { scrollLeft, scrollWidth, clientWidth } = container;
@@ -72,9 +73,12 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
 
     setShowLeftArrow(!isAtStart);
     setShowRightArrow(!isAtEnd);
+  }, []);
 
+  const handleCourseGridScroll = useCallback(() => {
+    updateScrollButtons();
     closePopover();
-  }, [closePopover]);
+  }, [closePopover, updateScrollButtons]);
 
   const scroll = useCallback(
     (direction) => {
@@ -85,9 +89,9 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
         left: direction === 'right' ? scrollDistance : -scrollDistance,
         behavior: 'smooth',
       });
-      setTimeout(checkScrollState, 500); // 滾動完成後檢查狀態
+      setTimeout(updateScrollButtons, 500); // 滾動完成後檢查狀態
     },
-    [checkScrollState]
+    [updateScrollButtons]
   );
 
   useEffect(() => {
@@ -105,7 +109,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
         const response = await CourseService.getAllCourses();
         const shuffledCourses = shuffleArray(response.data);
         setCourses(shuffledCourses);
-        setTimeout(checkScrollState, 0);
+        setTimeout(updateScrollButtons, 0);
       } catch (error) {
         console.error('獲取課程資料失敗:', error);
         setError('獲取課程資料失敗');
@@ -115,20 +119,37 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     };
 
     fetchCourses();
+  }, [updateScrollButtons]);
 
+  useEffect(() => {
     const container = containerRef.current;
-    if (container) {
-      container.addEventListener('scroll', checkScrollState);
-      window.addEventListener('scroll', closePopover, { passive: true });
-      window.addEventListener('resize', checkScrollState);
-      return () => {
-        container.removeEventListener('scroll', checkScrollState);
-        window.removeEventListener('scroll', closePopover);
-        window.removeEventListener('resize', checkScrollState);
-        clearCloseTimer();
-      };
-    }
-  }, [checkScrollState, clearCloseTimer, closePopover]);
+    if (!container) return undefined;
+
+    container.addEventListener('scroll', handleCourseGridScroll);
+    return () => {
+      container.removeEventListener('scroll', handleCourseGridScroll);
+    };
+  }, [handleCourseGridScroll]);
+
+  useEffect(() => {
+    if (!isPopoverOpen) return undefined;
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') closePopover();
+    };
+
+    window.addEventListener('scroll', closePopover, { passive: true });
+    window.addEventListener('resize', closePopover);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('scroll', closePopover);
+      window.removeEventListener('resize', closePopover);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closePopover, isPopoverOpen]);
+
+  useEffect(() => clearCloseTimer, [clearCloseTimer]);
 
   // 添加觸摸滑動支持
   useEffect(() => {

--- a/client/src/components/course/CourseCardScroller.jsx
+++ b/client/src/components/course/CourseCardScroller.jsx
@@ -6,6 +6,9 @@ import CourseHoverPopover from './CourseHoverPopover';
 import ScrollButton from './ScrollButton';
 import CourseSkeleton from './CourseSkeleton';
 
+const HOVER_CLOSE_GRACE_MS = 140;
+const POPOVER_EXIT_ANIMATION_MS = 120;
+
 const CourseCardScroller = ({ showAlert, currentUser }) => {
   const [courses, setCourses] = useState([]);
   const [showLeftArrow, setShowLeftArrow] = useState(false);
@@ -18,13 +21,18 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
 
   const containerRef = useRef(null);
   const cardsRef = useRef([]);
-  const closeTimerRef = useRef(null);
+  const closeGraceTimerRef = useRef(null);
+  const exitAnimationTimerRef = useRef(null);
   const isPopoverOpen = Boolean(hoveredCourse && anchorRect);
 
   const clearCloseTimer = useCallback(() => {
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
+    if (closeGraceTimerRef.current) {
+      clearTimeout(closeGraceTimerRef.current);
+      closeGraceTimerRef.current = null;
+    }
+    if (exitAnimationTimerRef.current) {
+      clearTimeout(exitAnimationTimerRef.current);
+      exitAnimationTimerRef.current = null;
     }
     setIsPopoverClosing(false);
   }, []);
@@ -47,12 +55,16 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
 
   const scheduleClosePopover = useCallback(() => {
     clearCloseTimer();
-    setIsPopoverClosing(true);
-    closeTimerRef.current = setTimeout(() => {
-      setHoveredCourse(null);
-      setAnchorRect(null);
-      setIsPopoverClosing(false);
-    }, 120);
+    closeGraceTimerRef.current = setTimeout(() => {
+      closeGraceTimerRef.current = null;
+      setIsPopoverClosing(true);
+      exitAnimationTimerRef.current = setTimeout(() => {
+        setHoveredCourse(null);
+        setAnchorRect(null);
+        setIsPopoverClosing(false);
+        exitAnimationTimerRef.current = null;
+      }, POPOVER_EXIT_ANIMATION_MS);
+    }, HOVER_CLOSE_GRACE_MS);
   }, [clearCloseTimer]);
 
   const handleCardMouseEnter = useCallback(

--- a/client/src/components/course/CourseCardScroller.jsx
+++ b/client/src/components/course/CourseCardScroller.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import CourseService from '../../services/course.service';
 import CourseCard from './CourseCard';
+import CourseHoverPopover from './CourseHoverPopover';
 import ScrollButton from './ScrollButton';
 import CourseSkeleton from './CourseSkeleton';
 
@@ -8,12 +9,44 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   const [courses, setCourses] = useState([]);
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(true);
-  const [nearRightEdge, setNearRightEdge] = useState([]);
+  const [hoveredCourse, setHoveredCourse] = useState(null);
+  const [anchorRect, setAnchorRect] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const containerRef = useRef(null);
   const cardsRef = useRef([]);
+  const closeTimerRef = useRef(null);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const closePopover = useCallback(() => {
+    clearCloseTimer();
+    setHoveredCourse(null);
+    setAnchorRect(null);
+  }, [clearCloseTimer]);
+
+  const scheduleClosePopover = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = setTimeout(() => {
+      setHoveredCourse(null);
+      setAnchorRect(null);
+    }, 120);
+  }, [clearCloseTimer]);
+
+  const handleCardMouseEnter = useCallback(
+    (course, cardElement) => {
+      clearCloseTimer();
+      setHoveredCourse(course);
+      setAnchorRect(cardElement.getBoundingClientRect());
+    },
+    [clearCloseTimer]
+  );
 
   const checkScrollState = useCallback(() => {
     if (!containerRef.current) return;
@@ -25,19 +58,8 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     setShowLeftArrow(!isAtStart);
     setShowRightArrow(!isAtEnd);
 
-    const threshold = 100;
-    setNearRightEdge(
-      cardsRef.current.map((card) => {
-        if (!card) return false;
-        const cardRect = card.getBoundingClientRect();
-        const containerRect = container.getBoundingClientRect();
-        return (
-          cardRect.left < containerRect.right &&
-          containerRect.right - cardRect.right < threshold
-        );
-      })
-    );
-  }, [setNearRightEdge]);
+    closePopover();
+  }, [closePopover]);
 
   const scroll = useCallback(
     (direction) => {
@@ -82,13 +104,16 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     const container = containerRef.current;
     if (container) {
       container.addEventListener('scroll', checkScrollState);
+      window.addEventListener('scroll', closePopover, { passive: true });
       window.addEventListener('resize', checkScrollState);
       return () => {
         container.removeEventListener('scroll', checkScrollState);
+        window.removeEventListener('scroll', closePopover);
         window.removeEventListener('resize', checkScrollState);
+        clearCloseTimer();
       };
     }
-  }, [checkScrollState]);
+  }, [checkScrollState, clearCloseTimer, closePopover]);
 
   // 添加觸摸滑動支持
   useEffect(() => {
@@ -153,7 +178,8 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
             course={course}
             showAlert={showAlert}
             currentUser={currentUser}
-            isNearRightEdge={nearRightEdge[index]}
+            onCardMouseEnter={handleCardMouseEnter}
+            onCardMouseLeave={scheduleClosePopover}
           />
         ))}
       </div>
@@ -161,6 +187,14 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
         direction="right"
         onClick={() => scroll('right')}
         isVisible={showRightArrow}
+      />
+      <CourseHoverPopover
+        course={hoveredCourse}
+        anchorRect={anchorRect}
+        showAlert={showAlert}
+        currentUser={currentUser}
+        onMouseEnter={clearCloseTimer}
+        onMouseLeave={scheduleClosePopover}
       />
     </div>
   );

--- a/client/src/components/course/CourseCardScroller.jsx
+++ b/client/src/components/course/CourseCardScroller.jsx
@@ -17,6 +17,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   const containerRef = useRef(null);
   const cardsRef = useRef([]);
   const closeTimerRef = useRef(null);
+  const anchorElementRef = useRef(null);
 
   const clearCloseTimer = useCallback(() => {
     if (closeTimerRef.current) {
@@ -27,6 +28,7 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
 
   const closePopover = useCallback(() => {
     clearCloseTimer();
+    anchorElementRef.current = null;
     setHoveredCourse(null);
     setAnchorRect(null);
   }, [clearCloseTimer]);
@@ -34,14 +36,35 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
   const scheduleClosePopover = useCallback(() => {
     clearCloseTimer();
     closeTimerRef.current = setTimeout(() => {
+      anchorElementRef.current = null;
       setHoveredCourse(null);
       setAnchorRect(null);
     }, 120);
   }, [clearCloseTimer]);
 
+  const updatePopoverPosition = useCallback(() => {
+    const anchorElement = anchorElementRef.current;
+    if (!anchorElement) return;
+
+    const nextRect = anchorElement.getBoundingClientRect();
+    const isVisible =
+      nextRect.bottom > 0 &&
+      nextRect.top < window.innerHeight &&
+      nextRect.right > 0 &&
+      nextRect.left < window.innerWidth;
+
+    if (!isVisible) {
+      closePopover();
+      return;
+    }
+
+    setAnchorRect(nextRect);
+  }, [closePopover]);
+
   const handleCardMouseEnter = useCallback(
     (course, cardElement) => {
       clearCloseTimer();
+      anchorElementRef.current = cardElement;
       setHoveredCourse(course);
       setAnchorRect(cardElement.getBoundingClientRect());
     },
@@ -58,8 +81,8 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     setShowLeftArrow(!isAtStart);
     setShowRightArrow(!isAtEnd);
 
-    closePopover();
-  }, [closePopover]);
+    updatePopoverPosition();
+  }, [updatePopoverPosition]);
 
   const scroll = useCallback(
     (direction) => {
@@ -104,16 +127,18 @@ const CourseCardScroller = ({ showAlert, currentUser }) => {
     const container = containerRef.current;
     if (container) {
       container.addEventListener('scroll', checkScrollState);
-      window.addEventListener('scroll', closePopover, { passive: true });
+      window.addEventListener('scroll', updatePopoverPosition, {
+        passive: true,
+      });
       window.addEventListener('resize', checkScrollState);
       return () => {
         container.removeEventListener('scroll', checkScrollState);
-        window.removeEventListener('scroll', closePopover);
+        window.removeEventListener('scroll', updatePopoverPosition);
         window.removeEventListener('resize', checkScrollState);
         clearCloseTimer();
       };
     }
-  }, [checkScrollState, clearCloseTimer, closePopover]);
+  }, [checkScrollState, clearCloseTimer, updatePopoverPosition]);
 
   // 添加觸摸滑動支持
   useEffect(() => {

--- a/client/src/components/course/CourseDetails.jsx
+++ b/client/src/components/course/CourseDetails.jsx
@@ -108,7 +108,7 @@ const CourseDetails = ({ course, showAlert, currentUser }) => {
     //   }}
     // >
 
-    <div className="course-details-card d-flex flex-column h-100">
+    <div className="course-details-card d-flex flex-column">
       <h5 className="fw-bold mb-2 lh-base">{course.title}</h5>
       
       <div className="d-flex align-items-center mb-2">
@@ -120,30 +120,32 @@ const CourseDetails = ({ course, showAlert, currentUser }) => {
         總計 {7} 小時 · 所有級別 · 字幕
       </div>
 
-      <p className="small mb-3 lh-sm" style={{ color: '#1c1d1f' }}>
-        {course.description}
-      </p>
+      <div className="course-details-body">
+        <p className="small mb-3 lh-sm course-details-description" style={{ color: '#1c1d1f' }}>
+          {course.description}
+        </p>
 
       {/* 模擬的課程特點清單 */}
-      <ul className="list-unstyled small mb-4 flex-grow-1" style={{ color: '#1c1d1f' }}>
-        <li className="d-flex align-items-start mb-2">
+        <ul className="list-unstyled small mb-0 course-details-points" style={{ color: '#1c1d1f' }}>
+          <li className="d-flex align-items-start mb-2">
           <span className="me-2 mt-1">✓</span>
-          <span>了解 {course.title} 的核心基礎與架構</span>
-        </li>
-        <li className="d-flex align-items-start mb-2">
+          <span className="course-details-point-text">了解課程核心基礎與架構</span>
+          </li>
+          <li className="d-flex align-items-start mb-2">
           <span className="me-2 mt-1">✓</span>
-          <span>掌握實務技巧，應用於真實專案開發</span>
-        </li>
-        <li className="d-flex align-items-start mb-2">
+          <span className="course-details-point-text">掌握實務技巧，應用於真實專案開發</span>
+          </li>
+          <li className="d-flex align-items-start mb-2">
           <span className="me-2 mt-1">✓</span>
-          <span>深入淺出解析困難概念，從小白到精通</span>
-        </li>
-      </ul>
+          <span className="course-details-point-text">循序解析困難概念，建立完整理解</span>
+          </li>
+        </ul>
+      </div>
 
       <button
         type="button"
         onClick={handleEnroll}
-        className="btn btn-purple py-2 fw-bold w-100 mt-auto"
+        className="btn btn-purple py-2 fw-bold w-100 mt-3"
         style={{ borderRadius: '8px' }}
         disabled={isEnrolled || isEnrolling}
       >

--- a/client/src/components/course/CourseHoverPopover.jsx
+++ b/client/src/components/course/CourseHoverPopover.jsx
@@ -14,8 +14,10 @@ const CourseHoverPopover = ({
   anchorRect,
   showAlert,
   currentUser,
+  isClosing,
   onMouseEnter,
   onMouseLeave,
+  onWheel,
 }) => {
   const position = useMemo(() => {
     if (!anchorRect) return null;
@@ -56,10 +58,11 @@ const CourseHoverPopover = ({
     <div
       className={`course-hover-popover ${
         position.alignRight ? 'align-right' : 'align-left'
-      }`}
+      } ${isClosing ? 'is-closing' : ''}`}
       style={position.style}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onWheelCapture={onWheel}
     >
       <CourseDetails
         course={course}

--- a/client/src/components/course/CourseHoverPopover.jsx
+++ b/client/src/components/course/CourseHoverPopover.jsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import CourseDetails from './CourseDetails';
+
+const POPOVER_WIDTH = 320;
+const POPOVER_MAX_HEIGHT = 544;
+const GAP = 16;
+const EDGE_PADDING = 16;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const CourseHoverPopover = ({
+  course,
+  anchorRect,
+  showAlert,
+  currentUser,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  const position = useMemo(() => {
+    if (!anchorRect) return null;
+
+    const rightSpace = window.innerWidth - anchorRect.right;
+    const alignRight = rightSpace >= POPOVER_WIDTH + GAP + EDGE_PADDING;
+    const left = alignRight
+      ? anchorRect.right + GAP
+      : anchorRect.left - POPOVER_WIDTH - GAP;
+
+    const visibleHeight = Math.min(
+      POPOVER_MAX_HEIGHT,
+      window.innerHeight - EDGE_PADDING * 2
+    );
+    const top = clamp(
+      anchorRect.top,
+      EDGE_PADDING,
+      window.innerHeight - visibleHeight - EDGE_PADDING
+    );
+
+    return {
+      alignRight,
+      style: {
+        left: `${clamp(
+          left,
+          EDGE_PADDING,
+          window.innerWidth - POPOVER_WIDTH - EDGE_PADDING
+        )}px`,
+        top: `${top}px`,
+        width: `${POPOVER_WIDTH}px`,
+      },
+    };
+  }, [anchorRect]);
+
+  if (!course || !position) return null;
+
+  return createPortal(
+    <div
+      className={`course-hover-popover ${
+        position.alignRight ? 'align-right' : 'align-left'
+      }`}
+      style={position.style}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <CourseDetails
+        course={course}
+        showAlert={showAlert}
+        currentUser={currentUser}
+      />
+    </div>,
+    document.body
+  );
+};
+
+export default CourseHoverPopover;

--- a/client/src/components/course/CourseHoverPopover.jsx
+++ b/client/src/components/course/CourseHoverPopover.jsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom';
 import CourseDetails from './CourseDetails';
 
 const POPOVER_WIDTH = 320;
-const POPOVER_MAX_HEIGHT = 544;
 const GAP = 16;
 const EDGE_PADDING = 16;
 
@@ -28,15 +27,7 @@ const CourseHoverPopover = ({
       ? anchorRect.right + GAP
       : anchorRect.left - POPOVER_WIDTH - GAP;
 
-    const visibleHeight = Math.min(
-      POPOVER_MAX_HEIGHT,
-      window.innerHeight - EDGE_PADDING * 2
-    );
-    const top = clamp(
-      anchorRect.top,
-      EDGE_PADDING,
-      window.innerHeight - visibleHeight - EDGE_PADDING
-    );
+    const top = Math.max(anchorRect.top, EDGE_PADDING);
 
     return {
       alignRight,

--- a/client/src/styles/components/course-card.css
+++ b/client/src/styles/components/course-card.css
@@ -34,6 +34,24 @@
   position: fixed;
   z-index: 2000;
   pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  will-change: opacity, transform;
+}
+
+.course-hover-popover.is-closing {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(4px) scale(0.985);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .course-hover-popover {
+    transition: none;
+  }
 }
 
 .course-details-wrapper.align-right {

--- a/client/src/styles/components/course-card.css
+++ b/client/src/styles/components/course-card.css
@@ -36,16 +36,38 @@
   pointer-events: auto;
   opacity: 1;
   transform: translateY(0) scale(1);
+  animation: course-popover-enter 150ms cubic-bezier(0.16, 1, 0.3, 1);
   transition:
-    opacity 120ms ease,
-    transform 120ms ease;
+    opacity 150ms ease,
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
   will-change: opacity, transform;
 }
 
 .course-hover-popover.is-closing {
+  animation: none;
   opacity: 0;
   pointer-events: none;
-  transform: translateY(4px) scale(0.985);
+  transform: translateY(6px) scale(0.98);
+}
+
+.course-hover-popover.align-right {
+  transform-origin: left top;
+}
+
+.course-hover-popover.align-left {
+  transform-origin: right top;
+}
+
+@keyframes course-popover-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .course-hover-popover::after {
@@ -66,6 +88,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .course-hover-popover {
+    animation: none;
     transition: none;
   }
 }
@@ -89,8 +112,10 @@
   left: -10px; /* 箭頭黏在 details-card 的最左邊 */
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
-  border-right: 10px solid #fff;
-  filter: drop-shadow(-2px 0px 2px rgba(0, 0, 0, 0.05));
+  border-right: 10px solid #ffffff;
+  filter:
+    drop-shadow(-1px 0 0 rgba(17, 24, 39, 0.08))
+    drop-shadow(-4px 4px 6px rgba(17, 24, 39, 0.08));
 }
 
 /* 顯示左側（指標向右） */
@@ -102,17 +127,24 @@
   right: -10px; /* 箭頭黏在 details-card 的最右邊 */
   border-top: 10px solid transparent;
   border-bottom: 10px solid transparent;
-  border-left: 10px solid #fff;
-  filter: drop-shadow(2px 0px 2px rgba(0, 0, 0, 0.05));
+  border-left: 10px solid #ffffff;
+  filter:
+    drop-shadow(1px 0 0 rgba(17, 24, 39, 0.08))
+    drop-shadow(4px 4px 6px rgba(17, 24, 39, 0.08));
 }
 
 .course-details-card {
   width: 20rem; /* 大約與原本的圖片卡寬度相當 */
   max-height: min(34rem, calc(100vh - 4rem));
   min-height: 100%;
-  background: #fff;
+  background:
+    linear-gradient(180deg, #ffffff 0%, #ffffff 68%, #fbfbfd 100%);
+  border: 1px solid rgba(17, 24, 39, 0.08);
   border-radius: 8px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+  box-shadow:
+    0 18px 36px rgba(17, 24, 39, 0.16),
+    0 4px 10px rgba(17, 24, 39, 0.08),
+    0 0 0 1px rgba(255, 255, 255, 0.7) inset;
   padding: 1.2rem;
   position: relative;
   overflow: hidden;

--- a/client/src/styles/components/course-card.css
+++ b/client/src/styles/components/course-card.css
@@ -23,21 +23,16 @@
 }
 
 .course-details-wrapper {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  z-index: 1500;
-  transition:
-    opacity 0.1s ease,
-    visibility 0.1s ease;
+  display: none;
 }
 
-.course-card:hover .course-details-wrapper {
-  opacity: 1;
-  visibility: visible;
+.course-details-inline {
+  display: none;
+}
+
+.course-hover-popover {
+  position: fixed;
+  z-index: 2000;
   pointer-events: auto;
 }
 
@@ -52,7 +47,7 @@
 }
 
 /* 顯示右側（指標向左） */
-.course-details-wrapper.align-right .course-details-card::before {
+.course-hover-popover.align-right .course-details-card::before {
   content: "";
   position: absolute;
   top: 50%;
@@ -65,7 +60,7 @@
 }
 
 /* 顯示左側（指標向右） */
-.course-details-wrapper.align-left .course-details-card::before {
+.course-hover-popover.align-left .course-details-card::before {
   content: "";
   position: absolute;
   top: 50%;
@@ -79,13 +74,52 @@
 
 .course-details-card {
   width: 20rem; /* 大約與原本的圖片卡寬度相當 */
-  height: auto;
+  max-height: min(34rem, calc(100vh - 4rem));
   min-height: 100%;
   background: #fff;
   border-radius: 8px;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
   padding: 1.2rem;
   position: relative;
+  overflow: hidden;
+}
+
+.course-details-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  padding-right: 0.25rem;
+}
+
+.course-details-body::-webkit-scrollbar {
+  width: 0.35rem;
+}
+
+.course-details-body::-webkit-scrollbar-thumb {
+  background-color: #c7cbd1;
+  border-radius: 999px;
+}
+
+.course-details-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.course-details-points {
+  margin-bottom: 0;
+}
+
+.course-details-points li:last-child {
+  margin-bottom: 0 !important;
+}
+
+.course-details-point-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .course-card-scroller {
@@ -137,28 +171,38 @@
   }
 
   /* 手機版停用 Hover 彈出效果，改為靜態顯示（當詳情組件被渲染時） */
-  .course-details-wrapper {
-    position: static;
-    transform: none;
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    width: 100%;
-    padding: 0 !important;
+  .course-details-inline {
+    display: block;
   }
 
-  .course-details-wrapper.align-left,
-  .course-details-wrapper.align-right {
-    padding: 0 !important;
+  .course-hover-popover {
+    display: none;
   }
 
   .course-details-card {
     width: 100%;
+    max-height: none;
+    overflow: visible;
     box-shadow: none;
     border: none;
     border-top: 1px solid #dee2e6;
     border-radius: 0 0 8px 8px;
     padding: 1rem 0 0 0;
+  }
+
+  .course-details-body {
+    overflow: visible;
+    padding-right: 0;
+  }
+
+  .course-details-description {
+    display: block;
+    overflow: visible;
+  }
+
+  .course-details-point-text {
+    display: inline;
+    overflow: visible;
   }
 
   /* 隱藏手機版的箭頭 */

--- a/client/src/styles/components/course-card.css
+++ b/client/src/styles/components/course-card.css
@@ -48,6 +48,22 @@
   transform: translateY(4px) scale(0.985);
 }
 
+.course-hover-popover::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 16px;
+}
+
+.course-hover-popover.align-right::after {
+  left: -16px;
+}
+
+.course-hover-popover.align-left::after {
+  right: -16px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .course-hover-popover {
     transition: none;


### PR DESCRIPTION
﻿## Summary

Refactor the desktop course-card hover detail from a card-local absolute element into a viewport-aware portal popover, then tighten the hover interaction so it behaves like a stable course preview instead of a clipped child element.

This fixes the root UI issue where Course Detail looked like a floating layer but was still rendered inside the horizontal course scroller. Because the old detail panel lived under `.course-card-grid` / `.course-card-scroller`, long content and parent `overflow` rules could still cause clipping, awkward positioning, and unstable hover behavior even with a high `z-index`.

## What changed

- Render desktop hover detail through `createPortal()` into `document.body`.
- Position the popover with `position: fixed` using the hovered card's `getBoundingClientRect()` snapshot.
- Centralize hover state in `CourseCardScroller` instead of creating one popover per course card.
- Keep mobile behavior inline, so small screens continue using the expandable detail inside the course card.
- Convert the desktop hover content into a preview-style layout with line clamps and shorter learning points.
- Align the popover top with the hovered card instead of pushing it upward to satisfy a bottom viewport clamp.
- Dismiss the popover on wheel, page scroll, horizontal list scroll, resize, or Escape to avoid floating-layer drift.
- Add mousemove and pointerdown fallbacks for first-hover cases where the card renders under an already-positioned cursor.
- Guard the mousemove fallback so small pointer movements over the same card do not repeatedly reset state or replay animations.
- Add a short enter/exit animation and respect `prefers-reduced-motion`.
- Polish the hover card with a layered shadow, subtle border, restrained background depth, and matching arrow shadow.

## Technical Design

The main design decision is separating overlay ownership from list layout. The original detail panel was a child of `.course-card` inside a horizontal scroll container; increasing `z-index` could not fully solve clipping because `overflow` boundaries still apply. Moving the desktop detail into a portal makes it a true overlay, with viewport-based positioning and an explicit lifecycle.

This implementation uses a single centralized popover instance at the scroller level. Each `CourseCard` reports the hovered course and its DOM rect to the parent. `CourseCardScroller` owns `hoveredCourse`, `anchorRect`, closing state, wheel dismissal, scroll/resize/Escape dismissal, and active preview tracking. That avoids many cards creating independent portal lifecycles or duplicated overlay state.

For UX, the popover is treated as a hover preview, not a mini detail page. Wheel input means the user is leaving the current browse position, so the popover is dismissed during wheel capture before the browser scrolls. Normal mouse leave uses a short grace period followed by fade/scale exit animation so users can move from the card into the popover without a jarring disappearance.

The popover now prioritizes card-relative placement. It aligns to the hovered card's top edge and only applies a minimum top padding near the viewport top. This matches the expected course-card preview pattern better than forcing the full popover inside the viewport by pushing it far above the hovered card.

## Performance considerations

- Global scroll, resize, and Escape listeners are mounted only while the popover is open and are cleaned up when it closes or the component unmounts.
- Horizontal list scroll is handled by the shared scroller container, not by each course card.
- Wheel dismissal uses capture timing so the popover disappears before the page visually scrolls, preventing short-distance drift.
- The overlay is centralized at the `CourseCardScroller` level, avoiding per-card portal lifecycles and duplicated listener ownership.
- The mousemove fallback is guarded by the active course id and current closing state, so normal small pointer movement over the same card does not repeatedly update React state or restart animations.

## Edge cases considered

- Long descriptions are clamped so the hover preview does not become an oversized detail page.
- Long course titles no longer get repeated inside learning-point text.
- Right-edge cards can render the popover on the left side when there is not enough right-side viewport space.
- Mouse leave uses a delayed close so users can move from the card into the popover without immediate dismissal.
- First-hover cases are handled when a course card renders under an already-positioned cursor or the user clicks before a `mouseenter` event is observed.
- Small pointer movement over the active card no longer causes hover detail flicker.
- Fast hover movement reuses the single popover instance instead of rendering multiple competing popovers.
- Escape closes the popover while it is open.

## Follow-up considerations

- Add a separate click-to-open modal or drawer for full course detail. This should be a separate PR because it introduces a new intentional interaction beyond hover preview.
- Improve keyboard accessibility beyond Escape dismissal because the portal content contains an interactive CTA.
- Add focus-triggered opening, explicit focus management, and ARIA relationship semantics.
- Consider introducing `shortDescription` and structured `highlights` fields so hover previews do not depend on full course descriptions.

## Validation

- `npm run lint --prefix client`
- `npm run build`
